### PR TITLE
CLI Format Fixes

### DIFF
--- a/CLI.hpp
+++ b/CLI.hpp
@@ -122,7 +122,7 @@ void CLI::displayCLI ()
                     cout << "Enter new name of class:" << endl;
                     cin >> name2;
                     data.changeClassName(name, name2);
-                    cout << endl << "Class named " << name << " renamed to " << name2 << endl << endl;
+                    cout << endl << "Class named " << name << " renamed as " << name2 << endl << endl;
                     subLoop = false;
                 }
                 // Go back
@@ -161,7 +161,7 @@ void CLI::displayCLI ()
                     cout << "Enter the name of the attribute: "<< endl;
                     cin >> attributeName;
                     data.addClassAttribute(className, attributeName);
-                    cout << "Attribute " << attributeName << " added to " << className << endl;
+                    cout << endl << "Attribute " << attributeName << " added to " << className << endl << endl;
                     subLoop = false;
 
                 }
@@ -173,7 +173,7 @@ void CLI::displayCLI ()
                     cout << "Enter the name of the attribute: "<< endl;
                     cin >> attributeName;
                     data.removeClassAttribute(className, attributeName);
-                    cout << "Attribute " << attributeName << " removed from " << className << endl;
+                    cout << endl << "Attribute " << attributeName << " removed from " << className << endl << endl;
                     subLoop = false;
                 } 
                 // Rename class
@@ -189,6 +189,7 @@ void CLI::displayCLI ()
                     cin >> attributeName2;
                     data.removeClassAttribute(className, attributeName);
                     data.addClassAttribute(className, attributeName2);
+                    cout << endl << "Attribute " << attributeName << " renamed as " << attributeName2 << endl << endl;
                     subLoop = false;
                 }
                 // Go back
@@ -227,7 +228,7 @@ void CLI::displayCLI ()
                     cout << "Enter the name of the destination: "<< endl;
                     cin >> destination;
                     data.addRelationship(source, destination);
-                    cout << "Relationship added between " << source << " and " << destination << endl;
+                    cout << endl <<"Relationship added between " << source << " and " << destination << endl << endl;
                     subLoop = false;
                 }
                 // Remove relationship
@@ -238,7 +239,7 @@ void CLI::displayCLI ()
                     cout << "Enter the name of the destination: "<< endl;
                     cin >> destination;
                     data.deleteRelationship(source, destination);
-                    cout << "Relationship deleted between " << source << " and " << destination << endl;
+                    cout << endl << "Relationship deleted between " << source << " and " << destination << endl << endl;
                     subLoop = false;
                 } 
                 // Go back

--- a/CLI.hpp
+++ b/CLI.hpp
@@ -91,9 +91,8 @@ void CLI::displayCLI ()
                 cin >> userChoice;
                 cout << endl;
                 
-                // class names
-                string name;
-                string name2;
+                // class name input storage
+                string name, name2;
 
                 // Add class
                 if (userChoice == "0") {
@@ -152,7 +151,9 @@ void CLI::displayCLI ()
                 cin >> userChoice;
                 cout << endl;
 
+                // class and attribute name input storage
                 string className, attributeName;
+                
                 // Add attribute
                 if (userChoice == "0") {
                     // prompt name of class and attribute then add attribute
@@ -180,9 +181,9 @@ void CLI::displayCLI ()
                 else if (userChoice == "2") {
                     // prompt name of class, old attribute name, and new attribute name. 
                     // replace attribute with one of new name.
-                    cout << "Enter the name of the class: "<< endl;
+                    cout << "Enter the name of the class: " << endl;
                     cin >> className;
-                    cout << "Enter the name of the attribute: "<< endl;
+                    cout << "Enter the name of the attribute: " << endl;
                     cin >> attributeName;
                     cout << "Enter new name of attribute:" << endl;
                     string attributeName2;
@@ -223,9 +224,9 @@ void CLI::displayCLI ()
 
                 // Add relationship
                 if (userChoice == "0") {
-                    cout << "Enter the name of the source: "<< endl;
+                    cout << "Enter the name of the source: " << endl;
                     cin >> source;
-                    cout << "Enter the name of the destination: "<< endl;
+                    cout << "Enter the name of the destination: " << endl;
                     cin >> destination;
                     data.addRelationship(source, destination);
                     cout << endl <<"Relationship added between " << source << " and " << destination << endl << endl;
@@ -234,9 +235,9 @@ void CLI::displayCLI ()
                 // Remove relationship
                 else if (userChoice == "1") {
                     // prompt name of source and destination and removes relationship
-                    cout << "Enter the name of the source: "<< endl;
+                    cout << "Enter the name of the source: " << endl;
                     cin >> source;
-                    cout << "Enter the name of the destination: "<< endl;
+                    cout << "Enter the name of the destination: " << endl;
                     cin >> destination;
                     data.deleteRelationship(source, destination);
                     cout << endl << "Relationship deleted between " << source << " and " << destination << endl << endl;
@@ -268,11 +269,13 @@ void CLI::displayCLI ()
                 cin >> userChoice;
                 cout << endl;
 
+                // class name input storage
+                string name;
+
                 // Display single class
                 if (userChoice == "0") {
                     // prompt class name, shows information about class
                     cout << "Enter name of class:" << endl;
-                    string name;
                     cin >> name;
                     cout << "Attributes:" << endl;
                     UMLClass c = data.getClassCopy(name);
@@ -309,7 +312,6 @@ void CLI::displayCLI ()
                         }
                     }  
                     cout << endl << "Enter anything to continue..." << endl;
-                    std::string name;
                     cin >> name; //just to have a pause so user can have time to view attributes and relationships                 
                     subLoop = false;
                 } 
@@ -361,6 +363,8 @@ void CLI::displayCLI ()
                     myfile.close();
                 }
                 else cout << "Unable to open file";
+                cout << endl << "Enter anything to continue..." << endl;
+                cin >> line; //just to have a pause so user can have time to view help
                 cout << endl; 
                 subLoop = false;
             }

--- a/CLI.hpp
+++ b/CLI.hpp
@@ -47,6 +47,11 @@ class CLI
     public:
         // Displays command line interface
         void displayCLI();
+        // Displays information about classes within the diagram.
+        // Has conditional booleans to optionally display attributes and relationships.
+        void displayDiagram (bool displayAttribute, bool displayRelationship);
+        // Displays information about a single class with the name className.
+        void displayClass (string className);
 };
 
 
@@ -107,6 +112,8 @@ void CLI::displayCLI ()
                 }
                 // Remove class
                 else if (userChoice == "1") {
+                    // Display all classes
+                    displayDiagram(false, false);
                     // Prompt name of class then remove class
                     cout << "Enter name of class:" << endl;
                     cin >> name;
@@ -116,6 +123,8 @@ void CLI::displayCLI ()
                 } 
                 // Rename class
                 else if (userChoice == "2") {
+                    // Display all classes
+                    displayDiagram(false, false);
                     // Prompt name of class then rename class
                     cout << "Enter old name of class:" << endl;
                     string name;
@@ -158,6 +167,8 @@ void CLI::displayCLI ()
                 
                 // Add attribute
                 if (userChoice == "0") {
+                    // Display all classes
+                    displayDiagram(false, false);
                     // Prompt name of class and attribute then add attribute
                     cout << "Enter the name of the class: "<< endl;
                     cin >> className;
@@ -168,8 +179,10 @@ void CLI::displayCLI ()
                     subLoop = false;
 
                 }
-                // Remove class
+                // Remove attribute
                 else if (userChoice == "1") {
+                    // Display all classes and attributes
+                    displayDiagram(true, false);
                     // Prompt name of class and attribute then remove attribute
                     cout << "Enter the name of the class: "<< endl;
                     cin >> className;
@@ -179,8 +192,10 @@ void CLI::displayCLI ()
                     cout << endl << "Attribute " << attributeName << " removed from " << className << endl << endl;
                     subLoop = false;
                 } 
-                // Rename class
+                // Rename attribute
                 else if (userChoice == "2") {
+                    // Display all classes and attributes
+                    displayDiagram(true, false);
                     // Prompt name of class, old attribute name, and new attribute name. 
                     // Replace attribute with one of new name.
                     cout << "Enter the name of the class: " << endl;
@@ -226,6 +241,8 @@ void CLI::displayCLI ()
 
                 // Add relationship
                 if (userChoice == "0") {
+                    // Display all classes
+                    displayDiagram(false, false);
                     // Prompt name of source and destination and removes relationship
                     cout << "Enter the name of the source: " << endl;
                     cin >> source;
@@ -237,6 +254,8 @@ void CLI::displayCLI ()
                 }
                 // Remove relationship
                 else if (userChoice == "1") {
+                    // Display all classes and relationships
+                    displayDiagram(false, true);
                     // Prompt name of source and destination and removes relationship
                     cout << "Enter the name of the source: " << endl;
                     cin >> source;
@@ -280,24 +299,7 @@ void CLI::displayCLI ()
                     // Prompt class name
                     cout << "Enter name of class:" << endl;
                     cin >> name;
-                    
-                    // Grab copy of class in order to display attributes
-                    cout << "Attributes:" << endl;
-                    UMLClass c = data.getClassCopy(name);
-                    vector<UMLAttribute> attributeList = c.getAttributes();
-                    for(UMLAttribute attribute : attributeList)
-                    {
-                        cout << attribute.getAttributeName() << endl;
-                    }
-
-                    // Find relationships based on name of the class
-                    cout << "Relationships:" << endl;
-                    vector<UMLRelationship> relationshipList = data.getRelationshipsByClass(name);
-                    for(UMLRelationship relationship : relationshipList)
-                    {
-                        cout << relationship.getSource().getName() << " => " << relationship.getDestination().getName() << endl;
-                    }
-
+                    displayClass(name);
                     cout << endl << "Enter anything to continue..." << endl;
                     cin >> name; // Pause for input
                     cout << endl; 
@@ -305,21 +307,7 @@ void CLI::displayCLI ()
                 }
                 // Display all information
                 else if (userChoice == "1") {
-                    std::vector<UMLClass> classes = data.getClasses();
-                    for (UMLClass umlclass : classes)
-                    {
-                        std::cout << "Name: " << umlclass.getName() << std::endl;
-                        std::cout << "Attributes:" << std::endl;
-                        for (UMLAttribute attr : data.getClassAttributes(umlclass.getName()))
-                        {
-                            std::cout << attr.getAttributeName() << std::endl;
-                        }
-                        std::cout << "Relationships:" << std::endl;
-                        for (UMLRelationship rel : data.getRelationshipsByClass(umlclass.getName()))
-                        {
-                            std::cout << rel.getSource().getName() << " => " << rel.getDestination().getName() << std::endl;
-                        }
-                    }  
+                    displayDiagram (true, true); 
                     cout << endl << "Enter anything to continue..." << endl;
                     cin >> name; // Pause for input
                     cout << endl;                  
@@ -341,24 +329,24 @@ void CLI::displayCLI ()
             // Save UML
             else if (userChoice == "4") {
                 // Saves UML diagram to a JSON file in the same directory as the executable
-                std::cout << "Name of file: ";
+                cout << "Name of file: ";
                 std::string fileName;
                 std::cin >> fileName;
                 UMLFile file(fileName + ".json");
                 file.save(data);
-                std::cout << "Your file has been saved" << endl;
+                cout << "Your file has been saved" << endl;
                 subLoop = false;
             }
 
             // Load UML routine
             else if (userChoice == "5") {
                 // Ask for name of file, and then load UML data given the proper format
-                std::cout << "Name of file: ";
+                cout << "Name of file: ";
                 std::string fileName;
                 std::cin >> fileName;
                 UMLFile file(fileName + ".json");
                 data = file.load();
-                std::cout << "Your file has been loaded" << endl;
+                cout << "Your file has been loaded" << endl;
                 subLoop = false;
             }
 
@@ -395,6 +383,55 @@ void CLI::displayCLI ()
             }
         }  
     } 
+}
+
+void CLI::displayDiagram (bool displayAttribute, bool displayRelationship) 
+{
+    vector<UMLClass> classes = data.getClasses();
+    cout << "Classes:" << endl << endl;
+    for (UMLClass umlclass : classes)
+    {
+        cout << umlclass.getName() << std::endl;
+        if (displayAttribute) {
+            cout << "Attributes:" << std::endl;
+            for (UMLAttribute attr : data.getClassAttributes(umlclass.getName()))
+            {
+                cout << attr.getAttributeName() << std::endl;
+            }
+        }
+        if (displayRelationship) {
+            cout << "Relationships:" << std::endl;
+            for (UMLRelationship rel : data.getRelationshipsByClass(umlclass.getName()))
+            {
+                cout << rel.getSource().getName() << " => " << rel.getDestination().getName() << std::endl;
+            }
+        }
+        // Don't cause spacing within loop if only showing classes
+        if (displayAttribute || displayRelationship) cout << endl;
+    }
+    // Display single line break if only showing classes
+    if (!displayAttribute && !displayRelationship) cout << endl;
+}
+
+void CLI::displayClass (string className) 
+{
+    // Grab copy of class in order to display attributes
+    cout << "Attributes:" << endl;
+    UMLClass c = data.getClassCopy(className);
+    vector<UMLAttribute> attributeList = c.getAttributes();
+    for(UMLAttribute attribute : attributeList)
+    {
+        cout << attribute.getAttributeName() << endl;
+    }
+
+    // Find relationships based on name of the class
+    cout << "Relationships:" << endl;
+    vector<UMLRelationship> relationshipList = data.getRelationshipsByClass(className);
+    for(UMLRelationship relationship : relationshipList)
+    {
+        cout << relationship.getSource().getName() << " => " << relationship.getDestination().getName() << endl;
+    }
+    cout << endl;
 }
 
 /************************************************************/

--- a/CLI.hpp
+++ b/CLI.hpp
@@ -90,23 +90,27 @@ void CLI::displayCLI ()
                 cout << endl << "Choice: ";
                 cin >> userChoice;
                 cout << endl;
+                
+                // class names
+                string name;
+                string name2;
 
                 // Add class
                 if (userChoice == "0") {
                     // prompt name of class then add class
                     cout << "Enter name of class:" << endl;
-                    string name;
                     cin >> name;
                     data.addClass(name);
+                    cout << endl << "Class named " << name << " added" << endl << endl;
                     subLoop = false;
                 }
                 // Remove class
                 else if (userChoice == "1") {
                     // prompt name of class then remove class
                     cout << "Enter name of class:" << endl;
-                    string name;
                     cin >> name;
                     data.deleteClass(name);
+                    cout << endl << "Class named " << name << " removed" << endl << endl;
                     subLoop = false;
                 } 
                 // Rename class
@@ -116,9 +120,9 @@ void CLI::displayCLI ()
                     string name;
                     cin >> name;
                     cout << "Enter new name of class:" << endl;
-                    string name2;
                     cin >> name2;
                     data.changeClassName(name, name2);
+                    cout << endl << "Class named " << name << " renamed to " << name2 << endl << endl;
                     subLoop = false;
                 }
                 // Go back

--- a/CLI.hpp
+++ b/CLI.hpp
@@ -66,14 +66,14 @@ void CLI::displayCLI ()
     while (mainLoop) {
         // Main prompt: prompts user for options.
         cout << "Choose an option:" << endl;
-        cout << "[0] Class" << endl;
-        cout << "[1] Attribute" << endl;
-        cout << "[2] Relationship" << endl;
-        cout << "[3] List" << endl;
-        cout << "[4] Save" << endl;
-        cout << "[5] Load" << endl;
-        cout << "[6] Help" << endl;
-        cout << "[7] Exit" << endl;
+        cout << "[1] Class" << endl;
+        cout << "[2] Attribute" << endl;
+        cout << "[3] Relationship" << endl;
+        cout << "[4] List" << endl;
+        cout << "[5] Save" << endl;
+        cout << "[6] Load" << endl;
+        cout << "[7] Help" << endl;
+        cout << "[8] Exit" << endl;
 
         // Store user option
         cout << endl << "Choice: ";
@@ -85,13 +85,13 @@ void CLI::displayCLI ()
 
         while (subLoop) { 
             // Class subroutine
-            if(userChoice == "0") {
+            if(userChoice == "1") {
                 // Lists operations for modifying classes
                 cout << "Choose an option:" << endl;
-                cout << "[0] Add" << endl;
-                cout << "[1] Remove" << endl;
-                cout << "[2] Rename" << endl;
-                cout << "[3] Back" << endl;
+                cout << "[1] Add" << endl;
+                cout << "[2] Remove" << endl;
+                cout << "[3] Rename" << endl;
+                cout << "[4] Back" << endl;
 
                 // Store user option
                 cout << endl << "Choice: ";
@@ -102,41 +102,41 @@ void CLI::displayCLI ()
                 string name, name2;
 
                 // Add class
-                if (userChoice == "0") {
+                if (userChoice == "1") {
                     // Prompt name of class then add class
-                    cout << "Enter name of class:" << endl;
+                    cout << "Enter name of class: ";
                     cin >> name;
                     data.addClass(name);
                     cout << endl << "Class named " << name << " added" << endl << endl;
                     subLoop = false;
                 }
                 // Remove class
-                else if (userChoice == "1") {
-                    // Display all classes
+                else if (userChoice == "2") {
+                    // Display all class names
                     displayDiagram(false, false);
                     // Prompt name of class then remove class
-                    cout << "Enter name of class:" << endl;
+                    cout << "Enter name of class: ";
                     cin >> name;
                     data.deleteClass(name);
                     cout << endl << "Class named " << name << " removed" << endl << endl;
                     subLoop = false;
                 } 
                 // Rename class
-                else if (userChoice == "2") {
-                    // Display all classes
+                else if (userChoice == "3") {
+                    // Display all class names
                     displayDiagram(false, false);
                     // Prompt name of class then rename class
-                    cout << "Enter old name of class:" << endl;
+                    cout << "Enter old name of class: ";
                     string name;
                     cin >> name;
-                    cout << "Enter new name of class:" << endl;
+                    cout << "Enter new name of class: ";
                     cin >> name2;
                     data.changeClassName(name, name2);
                     cout << endl << "Class named " << name << " renamed to " << name2 << endl << endl;
                     subLoop = false;
                 }
                 // Go back
-                else if (userChoice == "3") {
+                else if (userChoice == "4") {
                     // Exits subroutine, goes back to main routine
                     subLoop = false;
                 }
@@ -144,18 +144,18 @@ void CLI::displayCLI ()
                 else {
                     // Show error, reset user choice
                     cout << "Invalid choice!" << endl << endl;
-                    userChoice = "0";
+                    userChoice = "1";
                 }
             }
 
             // Attribute subroutine
-            else if(userChoice == "1") {
+            else if(userChoice == "2") {
                 // Lists operations for modifying attributes
                 cout << "Choose an option:" << endl;
-                cout << "[0] Add" << endl;
-                cout << "[1] Remove" << endl;
-                cout << "[2] Rename" << endl;
-                cout << "[3] Back" << endl;
+                cout << "[1] Add" << endl;
+                cout << "[2] Remove" << endl;
+                cout << "[3] Rename" << endl;
+                cout << "[4] Back" << endl;
 
                 // Store user option
                 cout << endl << "Choice: ";
@@ -163,16 +163,16 @@ void CLI::displayCLI ()
                 cout << endl;
 
                 // Class and attribute name input storage
-                string className, attributeName;
+                string className, attributeName, attributeName2;
                 
                 // Add attribute
-                if (userChoice == "0") {
-                    // Display all classes
+                if (userChoice == "1") {
+                    // Display all class names
                     displayDiagram(false, false);
                     // Prompt name of class and attribute then add attribute
-                    cout << "Enter the name of the class: "<< endl;
+                    cout << "Enter the name of the class: ";
                     cin >> className;
-                    cout << "Enter the name of the attribute: "<< endl;
+                    cout << "Enter the name of the attribute: ";
                     cin >> attributeName;
                     data.addClassAttribute(className, attributeName);
                     cout << endl << "Attribute " << attributeName << " added to " << className << endl << endl;
@@ -180,38 +180,36 @@ void CLI::displayCLI ()
 
                 }
                 // Remove attribute
-                else if (userChoice == "1") {
+                else if (userChoice == "2") {
                     // Display all classes and attributes
                     displayDiagram(true, false);
                     // Prompt name of class and attribute then remove attribute
-                    cout << "Enter the name of the class: "<< endl;
+                    cout << "Enter the name of the class: ";
                     cin >> className;
-                    cout << "Enter the name of the attribute: "<< endl;
+                    cout << "Enter the name of the attribute: ";
                     cin >> attributeName;
                     data.removeClassAttribute(className, attributeName);
                     cout << endl << "Attribute " << attributeName << " removed from " << className << endl << endl;
                     subLoop = false;
                 } 
                 // Rename attribute
-                else if (userChoice == "2") {
+                else if (userChoice == "3") {
                     // Display all classes and attributes
                     displayDiagram(true, false);
                     // Prompt name of class, old attribute name, and new attribute name. 
                     // Replace attribute with one of new name.
-                    cout << "Enter the name of the class: " << endl;
+                    cout << "Enter the name of the class: ";
                     cin >> className;
-                    cout << "Enter the name of the attribute: " << endl;
+                    cout << "Enter the name of the attribute: ";
                     cin >> attributeName;
-                    cout << "Enter new name of attribute:" << endl;
-                    string attributeName2;
+                    cout << "Enter new name of attribute: ";
                     cin >> attributeName2;
-                    data.removeClassAttribute(className, attributeName);
-                    data.addClassAttribute(className, attributeName2);
+                    data.changeAttributeName(className, attributeName, attributeName2);
                     cout << endl << "Attribute " << attributeName << " renamed to " << attributeName2 << endl << endl;
                     subLoop = false;
                 }
                 // Go back
-                else if (userChoice == "3") {
+                else if (userChoice == "4") {
                     // Exits subroutine, goes back to main routine
                     subLoop = false;
                 }
@@ -219,17 +217,17 @@ void CLI::displayCLI ()
                 else {
                     // Show error, reset user choice
                     cout << "Invalid choice" << endl << endl;
-                    userChoice = "1";
+                    userChoice = "2";
                 }
             }
 
-            // Relationship
-            else if(userChoice == "2") {
+            // Relationship subroutine
+            else if(userChoice == "3") {
                 // Lists operations for modifying relationships
                 cout << "Choose an option:" << endl;
-                cout << "[0] Add" << endl;
-                cout << "[1] Remove" << endl;
-                cout << "[2] Back" << endl;
+                cout << "[1] Add" << endl;
+                cout << "[2] Remove" << endl;
+                cout << "[3] Back" << endl;
 
                 // Store user option
                 cout << endl << "Choice: ";
@@ -240,7 +238,7 @@ void CLI::displayCLI ()
                 string source, destination;
 
                 // Add relationship
-                if (userChoice == "0") {
+                if (userChoice == "1") {
                     // Display all classes
                     displayDiagram(false, false);
                     // Prompt name of source and destination and removes relationship
@@ -253,7 +251,7 @@ void CLI::displayCLI ()
                     subLoop = false;
                 }
                 // Remove relationship
-                else if (userChoice == "1") {
+                else if (userChoice == "2") {
                     // Display all classes and relationships
                     displayDiagram(false, true);
                     // Prompt name of source and destination and removes relationship
@@ -266,55 +264,7 @@ void CLI::displayCLI ()
                     subLoop = false;
                 } 
                 // Go back
-                else if (userChoice == "2") {
-                    // Exits subroutine, goes back to main routine
-                    subLoop = false;
-                }
-                // Invalid choice
-                else {
-                    // Show error, reset user choice
-                    cout << "Invalid choice!" << endl << endl;
-                    userChoice = "2";
-                }
-            }
-
-            // Diagram
-            else if(userChoice == "3") {
-                // Lists operations for viewing information within the diagram
-                cout << "Choose an option:" << endl;
-                cout << "[0] Class" << endl;
-                cout << "[1] Diagram" << endl;
-                cout << "[2] Back" << endl;
-
-                // Store user option
-                cout << endl << "Choice: ";
-                cin >> userChoice;
-                cout << endl;
-
-                // Class name input storage
-                string name;
-
-                // Display single class
-                if (userChoice == "0") {
-                    // Prompt class name
-                    cout << "Enter name of class:" << endl;
-                    cin >> name;
-                    displayClass(name);
-                    cout << endl << "Enter anything to continue..." << endl;
-                    cin >> name; // Pause for input
-                    cout << endl; 
-                    subLoop = false;
-                }
-                // Display all information
-                else if (userChoice == "1") {
-                    displayDiagram (true, true); 
-                    cout << endl << "Enter anything to continue..." << endl;
-                    cin >> name; // Pause for input
-                    cout << endl;                  
-                    subLoop = false;
-                } 
-                // Go back
-                else if (userChoice == "2") {
+                else if (userChoice == "3") {
                     // Exits subroutine, goes back to main routine
                     subLoop = false;
                 }
@@ -326,8 +276,58 @@ void CLI::displayCLI ()
                 }
             }
 
-            // Save UML
-            else if (userChoice == "4") {
+            // List subroutine
+            else if(userChoice == "4") {
+                // Lists operations for viewing information within the diagram
+                cout << "Choose an option:" << endl;
+                cout << "[1] Class" << endl;
+                cout << "[2] Diagram" << endl;
+                cout << "[3] Back" << endl;
+
+                // Store user option
+                cout << endl << "Choice: ";
+                cin >> userChoice;
+                cout << endl;
+
+                // Class name input storage
+                string name;
+
+                // Display single class
+                if (userChoice == "1") {
+                    // Display class names
+                    displayDiagram (false, false); 
+                    // Prompt class name
+                    cout << "Enter name of class:" << endl;
+                    cin >> name;
+                    displayClass(name);
+                    cout << endl << "Enter anything to continue..." << endl;
+                    cin >> name; // Pause for input
+                    cout << endl; 
+                    subLoop = false;
+                }
+                // Display all information
+                else if (userChoice == "2") {
+                    displayDiagram (true, true); 
+                    cout << "Enter anything to continue..." << endl;
+                    cin >> name; // Pause for input
+                    cout << endl;                  
+                    subLoop = false;
+                } 
+                // Go back
+                else if (userChoice == "3") {
+                    // Exits subroutine, goes back to main routine
+                    subLoop = false;
+                }
+                // Invalid choice
+                else {
+                    // Show error, reset user choice
+                    cout << "Invalid choice!" << endl << endl;
+                    userChoice = "4";
+                }
+            }
+
+            // Save UML subroutine
+            else if (userChoice == "5") {
                 // Saves UML diagram to a JSON file in the same directory as the executable
                 cout << "Name of file: ";
                 std::string fileName;
@@ -338,8 +338,8 @@ void CLI::displayCLI ()
                 subLoop = false;
             }
 
-            // Load UML routine
-            else if (userChoice == "5") {
+            // Load UML subroutine
+            else if (userChoice == "6") {
                 // Ask for name of file, and then load UML data given the proper format
                 cout << "Name of file: ";
                 std::string fileName;
@@ -350,8 +350,8 @@ void CLI::displayCLI ()
                 subLoop = false;
             }
 
-            // Help
-            else if (userChoice == "6") {
+            // Help subroutine
+            else if (userChoice == "7") {
                 // Displays help if help file exists, otherwise display error
                 string line;
                 std::ifstream myfile ("../help.txt");
@@ -369,7 +369,7 @@ void CLI::displayCLI ()
             }
 
             // Exits the program
-            else if (userChoice == "7") {
+            else if (userChoice == "8") {
                 subLoop = false;
                 mainLoop = false;
             }
@@ -389,21 +389,20 @@ void CLI::displayDiagram (bool displayAttribute, bool displayRelationship)
 {
     vector<UMLClass> classes = data.getClasses();
     cout << "Classes:" << endl << endl;
-    for (UMLClass umlclass : classes)
-    {
-        cout << umlclass.getName() << std::endl;
+    for (UMLClass umlclass : classes) {
+        cout << umlclass.getName() << endl;
         if (displayAttribute) {
-            cout << "Attributes:" << std::endl;
+            cout << "Attributes:" << endl;
             for (UMLAttribute attr : data.getClassAttributes(umlclass.getName()))
             {
-                cout << attr.getAttributeName() << std::endl;
+                cout << attr.getAttributeName() << endl;
             }
         }
         if (displayRelationship) {
-            cout << "Relationships:" << std::endl;
+            cout << "Relationships:" << endl;
             for (UMLRelationship rel : data.getRelationshipsByClass(umlclass.getName()))
             {
-                cout << rel.getSource().getName() << " => " << rel.getDestination().getName() << std::endl;
+                cout << rel.getSource().getName() << " => " << rel.getDestination().getName() << endl;
             }
         }
         // Don't cause spacing within loop if only showing classes
@@ -431,7 +430,6 @@ void CLI::displayClass (string className)
     {
         cout << relationship.getSource().getName() << " => " << relationship.getDestination().getName() << endl;
     }
-    cout << endl;
 }
 
 /************************************************************/

--- a/CLI.hpp
+++ b/CLI.hpp
@@ -36,29 +36,31 @@
 class CLI
 {
     private:
-        // stores choice input by user
+        // Stores choice input by user
         string userChoice;
-        // loop boolean that maintains CLI routine
+        // Loop boolean that maintains CLI routine
         bool mainLoop;
-        // loop boolean that maintains CLI subrountines
+        // Loop boolean that maintains CLI subrountines
         bool subLoop;
-        // main UML data object storing UML stuff
+        // Main UML data object storing UML stuff
         UMLData data;
     public:
-        // displays command line interface
+        // Displays command line interface
         void displayCLI();
 };
 
+
+// Displays CLI using a large loop routine.
 void CLI::displayCLI ()
 {
-    // loop boolean that maintains CLI routine
+    // Start default state of loops
     mainLoop = true;
-    // loop boolean that maintains CLI subrountines
     subLoop = false;
 
+    // Primary display routine
     while (mainLoop) {
         // Main prompt: prompts user for options.
-        cout << "Choose an option:"<< endl;
+        cout << "Choose an option:" << endl;
         cout << "[0] Class" << endl;
         cout << "[1] Attribute" << endl;
         cout << "[2] Relationship" << endl;
@@ -68,35 +70,35 @@ void CLI::displayCLI ()
         cout << "[6] Help" << endl;
         cout << "[7] Exit" << endl;
 
-        // store user option
+        // Store user option
         cout << endl << "Choice: ";
         cin >> userChoice;
         cout << endl;
 
-        // start subloop
+        // Start subloop
         subLoop = true;
 
         while (subLoop) { 
-            // Class
+            // Class subroutine
             if(userChoice == "0") {
                 // Lists operations for modifying classes
-                cout << "Choose an option:"<< endl;
+                cout << "Choose an option:" << endl;
                 cout << "[0] Add" << endl;
                 cout << "[1] Remove" << endl;
                 cout << "[2] Rename" << endl;
                 cout << "[3] Back" << endl;
 
-                // store user option
+                // Store user option
                 cout << endl << "Choice: ";
                 cin >> userChoice;
                 cout << endl;
                 
-                // class name input storage
+                // Class name input storage
                 string name, name2;
 
                 // Add class
                 if (userChoice == "0") {
-                    // prompt name of class then add class
+                    // Prompt name of class then add class
                     cout << "Enter name of class:" << endl;
                     cin >> name;
                     data.addClass(name);
@@ -105,7 +107,7 @@ void CLI::displayCLI ()
                 }
                 // Remove class
                 else if (userChoice == "1") {
-                    // prompt name of class then remove class
+                    // Prompt name of class then remove class
                     cout << "Enter name of class:" << endl;
                     cin >> name;
                     data.deleteClass(name);
@@ -114,49 +116,49 @@ void CLI::displayCLI ()
                 } 
                 // Rename class
                 else if (userChoice == "2") {
-                    // prompt name of class then rename class
+                    // Prompt name of class then rename class
                     cout << "Enter old name of class:" << endl;
                     string name;
                     cin >> name;
                     cout << "Enter new name of class:" << endl;
                     cin >> name2;
                     data.changeClassName(name, name2);
-                    cout << endl << "Class named " << name << " renamed as " << name2 << endl << endl;
+                    cout << endl << "Class named " << name << " renamed to " << name2 << endl << endl;
                     subLoop = false;
                 }
                 // Go back
                 else if (userChoice == "3") {
-                    // exits loop, goes back
+                    // Exits subroutine, goes back to main routine
                     subLoop = false;
                 }
                 // Invalid choice
                 else {
-                    // show error, reset user choice
+                    // Show error, reset user choice
                     cout << "Invalid choice!" << endl << endl;
                     userChoice = "0";
                 }
             }
 
-            // Attribute
+            // Attribute subroutine
             else if(userChoice == "1") {
                 // Lists operations for modifying attributes
-                cout << "Choose an option:"<< endl;
+                cout << "Choose an option:" << endl;
                 cout << "[0] Add" << endl;
                 cout << "[1] Remove" << endl;
                 cout << "[2] Rename" << endl;
                 cout << "[3] Back" << endl;
 
-                // store user option
+                // Store user option
                 cout << endl << "Choice: ";
                 cin >> userChoice;
                 cout << endl;
 
-                // class and attribute name input storage
+                // Class and attribute name input storage
                 string className, attributeName;
                 
                 // Add attribute
                 if (userChoice == "0") {
-                    // prompt name of class and attribute then add attribute
+                    // Prompt name of class and attribute then add attribute
                     cout << "Enter the name of the class: "<< endl;
                     cin >> className;
                     cout << "Enter the name of the attribute: "<< endl;
@@ -168,7 +170,7 @@ void CLI::displayCLI ()
                 }
                 // Remove class
                 else if (userChoice == "1") {
-                    // prompt name of class and attribute then remove attribute
+                    // Prompt name of class and attribute then remove attribute
                     cout << "Enter the name of the class: "<< endl;
                     cin >> className;
                     cout << "Enter the name of the attribute: "<< endl;
@@ -179,8 +181,8 @@ void CLI::displayCLI ()
                 } 
                 // Rename class
                 else if (userChoice == "2") {
-                    // prompt name of class, old attribute name, and new attribute name. 
-                    // replace attribute with one of new name.
+                    // Prompt name of class, old attribute name, and new attribute name. 
+                    // Replace attribute with one of new name.
                     cout << "Enter the name of the class: " << endl;
                     cin >> className;
                     cout << "Enter the name of the attribute: " << endl;
@@ -190,18 +192,18 @@ void CLI::displayCLI ()
                     cin >> attributeName2;
                     data.removeClassAttribute(className, attributeName);
                     data.addClassAttribute(className, attributeName2);
-                    cout << endl << "Attribute " << attributeName << " renamed as " << attributeName2 << endl << endl;
+                    cout << endl << "Attribute " << attributeName << " renamed to " << attributeName2 << endl << endl;
                     subLoop = false;
                 }
                 // Go back
                 else if (userChoice == "3") {
-                    // exits loop, goes back
+                    // Exits subroutine, goes back to main routine
                     subLoop = false;
                 }
                 // Invalid choice
                 else {
-                    // show error, reset user choice
-                    cout << "Invalid choice!" << endl << endl;
+                    // Show error, reset user choice
+                    cout << "Invalid choice" << endl << endl;
                     userChoice = "1";
                 }
             }
@@ -209,21 +211,22 @@ void CLI::displayCLI ()
             // Relationship
             else if(userChoice == "2") {
                 // Lists operations for modifying relationships
-                cout << "Choose an option:"<< endl;
+                cout << "Choose an option:" << endl;
                 cout << "[0] Add" << endl;
                 cout << "[1] Remove" << endl;
                 cout << "[2] Back" << endl;
 
-                // store user option
+                // Store user option
                 cout << endl << "Choice: ";
                 cin >> userChoice;
                 cout << endl;
 
-                // class name representing source and destination
+                // Class name representing source and destination
                 string source, destination;
 
                 // Add relationship
                 if (userChoice == "0") {
+                    // Prompt name of source and destination and removes relationship
                     cout << "Enter the name of the source: " << endl;
                     cin >> source;
                     cout << "Enter the name of the destination: " << endl;
@@ -234,7 +237,7 @@ void CLI::displayCLI ()
                 }
                 // Remove relationship
                 else if (userChoice == "1") {
-                    // prompt name of source and destination and removes relationship
+                    // Prompt name of source and destination and removes relationship
                     cout << "Enter the name of the source: " << endl;
                     cin >> source;
                     cout << "Enter the name of the destination: " << endl;
@@ -245,12 +248,12 @@ void CLI::displayCLI ()
                 } 
                 // Go back
                 else if (userChoice == "2") {
-                    // exits loop, goes back
+                    // Exits subroutine, goes back to main routine
                     subLoop = false;
                 }
                 // Invalid choice
                 else {
-                    // show error, reset user choice
+                    // Show error, reset user choice
                     cout << "Invalid choice!" << endl << endl;
                     userChoice = "2";
                 }
@@ -259,24 +262,26 @@ void CLI::displayCLI ()
             // Diagram
             else if(userChoice == "3") {
                 // Lists operations for viewing information within the diagram
-                cout << "Choose an option:"<< endl;
+                cout << "Choose an option:" << endl;
                 cout << "[0] Class" << endl;
                 cout << "[1] Diagram" << endl;
                 cout << "[2] Back" << endl;
 
-                // store user option
+                // Store user option
                 cout << endl << "Choice: ";
                 cin >> userChoice;
                 cout << endl;
 
-                // class name input storage
+                // Class name input storage
                 string name;
 
                 // Display single class
                 if (userChoice == "0") {
-                    // prompt class name, shows information about class
+                    // Prompt class name
                     cout << "Enter name of class:" << endl;
                     cin >> name;
+                    
+                    // Grab copy of class in order to display attributes
                     cout << "Attributes:" << endl;
                     UMLClass c = data.getClassCopy(name);
                     vector<UMLAttribute> attributeList = c.getAttributes();
@@ -284,14 +289,18 @@ void CLI::displayCLI ()
                     {
                         cout << attribute.getAttributeName() << endl;
                     }
+
+                    // Find relationships based on name of the class
                     cout << "Relationships:" << endl;
                     vector<UMLRelationship> relationshipList = data.getRelationshipsByClass(name);
                     for(UMLRelationship relationship : relationshipList)
                     {
-                        cout << relationship.getSource().getName() << " <=> " << relationship.getDestination().getName() << endl;
+                        cout << relationship.getSource().getName() << " => " << relationship.getDestination().getName() << endl;
                     }
+
                     cout << endl << "Enter anything to continue..." << endl;
-                    cin >> name; //just to have a pause so user can have time to view attributes and relationships
+                    cin >> name; // Pause for input
+                    cout << endl; 
                     subLoop = false;
                 }
                 // Display all information
@@ -308,21 +317,22 @@ void CLI::displayCLI ()
                         std::cout << "Relationships:" << std::endl;
                         for (UMLRelationship rel : data.getRelationshipsByClass(umlclass.getName()))
                         {
-                            std::cout << rel.getSource().getName() << " <=> " << rel.getDestination().getName() << std::endl;
+                            std::cout << rel.getSource().getName() << " => " << rel.getDestination().getName() << std::endl;
                         }
                     }  
                     cout << endl << "Enter anything to continue..." << endl;
-                    cin >> name; //just to have a pause so user can have time to view attributes and relationships                 
+                    cin >> name; // Pause for input
+                    cout << endl;                  
                     subLoop = false;
                 } 
                 // Go back
                 else if (userChoice == "2") {
-                    // exits loop, goes back
+                    // Exits subroutine, goes back to main routine
                     subLoop = false;
                 }
                 // Invalid choice
                 else {
-                    // show error, reset user choice
+                    // Show error, reset user choice
                     cout << "Invalid choice!" << endl << endl;
                     userChoice = "3";
                 }
@@ -336,18 +346,19 @@ void CLI::displayCLI ()
                 std::cin >> fileName;
                 UMLFile file(fileName + ".json");
                 file.save(data);
-                std::cout << "Your file has been saved!" << std::endl;
+                std::cout << "Your file has been saved" << endl;
                 subLoop = false;
             }
 
-            // Load UML
+            // Load UML routine
             else if (userChoice == "5") {
-                std::cout << "Name of file (<name>.json): ";
+                // Ask for name of file, and then load UML data given the proper format
+                std::cout << "Name of file: ";
                 std::string fileName;
                 std::cin >> fileName;
-                UMLFile file(fileName);
+                UMLFile file(fileName + ".json");
                 data = file.load();
-                std::cout << "Your file has been loaded!" << std::endl;
+                std::cout << "Your file has been loaded" << endl;
                 subLoop = false;
             }
 
@@ -364,7 +375,7 @@ void CLI::displayCLI ()
                 }
                 else cout << "Unable to open file";
                 cout << endl << "Enter anything to continue..." << endl;
-                cin >> line; //just to have a pause so user can have time to view help
+                cin >> line; // Pause for input
                 cout << endl; 
                 subLoop = false;
             }
@@ -377,7 +388,7 @@ void CLI::displayCLI ()
 
             // Invalid choice
             else {
-                // show error, reset user choice and break loop
+                // Show error, reset user choice and break loop
                 cout << "Invalid choice!" << endl << endl;
                 userChoice = "";
                 subLoop = false;

--- a/CLI.hpp
+++ b/CLI.hpp
@@ -74,7 +74,7 @@ void CLI::displayCLI ()
     mainLoop = true;
     subLoop = false;
 
-    cout << "Welcome to CLI++!" << endl << endl;
+    cout << "Welcome to UML++!" << endl << endl;
 
     // Primary display routine
     while (mainLoop) {
@@ -386,7 +386,7 @@ void CLI::displayCLI ()
                     myfile.close();
                 }
                 else cout << "Unable to open file";
-                
+
                 cout << endl << "Enter anything to continue..." << endl;
                 cin >> line; // Pause for input
                 cout << endl; 

--- a/CLI.hpp
+++ b/CLI.hpp
@@ -9,12 +9,13 @@
 #ifndef CLI_HPP
 #define CLI_HPP
 // Catch for functions to protect from invalid inputs
-#define ERR_CATCH(fun)           \
-    try {                        \
-        fun;                     \
-    }                            \
-    catch (const char* error) {  \
-        cout << error << endl;   \
+#define ERR_CATCH(fun)                           \
+    try {                                        \
+        fun;                                     \
+    }                                            \
+    catch (const char* error) {                  \
+        cout << endl << error << endl << endl;   \
+        errorStatus = true;                      \
     }
 /************************************************************/
 
@@ -44,12 +45,15 @@
 class CLI
 {
     private:
-        // Stores choice input by user
+        // Stores choice input by user, representing position within diagram
+        // When an invalid input is set, reverts to its previous position
         string userChoice;
         // Loop boolean that maintains CLI routine
         bool mainLoop;
         // Loop boolean that maintains CLI subrountines
         bool subLoop;
+        // Error check to prevent 'success' print 
+        bool errorStatus;
         // Main UML data object storing UML stuff
         UMLData data;
     public:
@@ -70,6 +74,8 @@ void CLI::displayCLI ()
     mainLoop = true;
     subLoop = false;
 
+    cout << "Welcome to CLI++!" << endl << endl;
+
     // Primary display routine
     while (mainLoop) {
         // Main prompt: prompts user for options.
@@ -83,7 +89,6 @@ void CLI::displayCLI ()
         cout << "[7] Help" << endl;
         cout << "[8] Exit" << endl;
 
-        // Store user option
         cout << endl << "Choice: ";
         cin >> userChoice;
         cout << endl;
@@ -100,8 +105,7 @@ void CLI::displayCLI ()
                 cout << "[2] Remove" << endl;
                 cout << "[3] Rename" << endl;
                 cout << "[4] Back" << endl;
-
-                // Store user option
+                
                 cout << endl << "Choice: ";
                 cin >> userChoice;
                 cout << endl;
@@ -111,49 +115,56 @@ void CLI::displayCLI ()
 
                 // Add class
                 if (userChoice == "1") {
-                    // Prompt name of class then add class
                     cout << "Enter name of class: ";
                     cin >> name;
+                    
                     // Catch for duplicate/invalid name
                     ERR_CATCH(data.addClass(name));
-                    cout << endl << "Class named " << name << " added" << endl << endl;
+                    // Prevent success message if error was caught
+                    if(errorStatus == false) cout << endl << "Class named " << name << " added" << endl << endl;
+                    else errorStatus = false;
                     subLoop = false;
                 }
                 // Remove class
                 else if (userChoice == "2") {
-                    // Display all class names
+                    // Display all class names for user clarity
                     displayDiagram(false, false);
-                    // Prompt name of class then remove class
+
                     cout << "Enter name of class: ";
                     cin >> name;
+
                     // Catch to see if name exists
                     ERR_CATCH(data.deleteClass(name));
-                    cout << endl << "Class named " << name << " removed" << endl << endl;
+                    // Prevent success message if error was caught
+                    if(errorStatus == false) cout << endl << "Class named " << name << " removed" << endl << endl;
+                    else errorStatus = false;
                     subLoop = false;
                 } 
                 // Rename class
                 else if (userChoice == "3") {
-                    // Display all class names
+                    // Display all class names for user clarity
                     displayDiagram(false, false);
-                    // Prompt name of class then rename class
+
                     cout << "Enter old name of class: ";
                     string name;
                     cin >> name;
                     cout << "Enter new name of class: ";
                     cin >> name2;
+
                     // Catch for duplicate/invalid name
                     ERR_CATCH(data.changeClassName(name, name2));
-                    cout << endl << "Class named " << name << " renamed to " << name2 << endl << endl;
+                    // Prevent success message if error was caught
+                    if(errorStatus == false) cout << endl << "Class named " << name << " renamed to " << name2 << endl << endl;
+                    else errorStatus = false;
                     subLoop = false;
                 }
                 // Go back
                 else if (userChoice == "4") {
-                    // Exits subroutine, goes back to main routine
+                    // Exits subroutine to go back to main routine
                     subLoop = false;
                 }
                 // Invalid choice
                 else {
-                    // Show error, reset user choice
                     cout << "Invalid choice!" << endl << endl;
                     userChoice = "1";
                 }
@@ -168,7 +179,6 @@ void CLI::displayCLI ()
                 cout << "[3] Rename" << endl;
                 cout << "[4] Back" << endl;
 
-                // Store user option
                 cout << endl << "Choice: ";
                 cin >> userChoice;
                 cout << endl;
@@ -178,13 +188,14 @@ void CLI::displayCLI ()
                 
                 // Add attribute
                 if (userChoice == "1") {
-                    // Display all class names
+                    // Display all class names for user clarity
                     displayDiagram(false, false);
-                    // Prompt name of class and attribute then add attribute
+                   
                     cout << "Enter the name of the class: ";
                     cin >> className;
                     cout << "Enter the name of the attribute: ";
                     cin >> attributeName;
+
                     data.addClassAttribute(className, attributeName);
                     cout << endl << "Attribute " << attributeName << " added to " << className << endl << endl;
                     subLoop = false;
@@ -192,41 +203,41 @@ void CLI::displayCLI ()
                 }
                 // Remove attribute
                 else if (userChoice == "2") {
-                    // Display all classes and attributes
+                    // Display all classes and attributes for user clarity
                     displayDiagram(true, false);
-                    // Prompt name of class and attribute then remove attribute
+                    
                     cout << "Enter the name of the class: ";
                     cin >> className;
                     cout << "Enter the name of the attribute: ";
                     cin >> attributeName;
+
                     data.removeClassAttribute(className, attributeName);
                     cout << endl << "Attribute " << attributeName << " removed from " << className << endl << endl;
                     subLoop = false;
                 } 
                 // Rename attribute
                 else if (userChoice == "3") {
-                    // Display all classes and attributes
+                    // Display all classes and attributes for user clarity
                     displayDiagram(true, false);
-                    // Prompt name of class, old attribute name, and new attribute name. 
-                    // Replace attribute with one of new name.
+
                     cout << "Enter the name of the class: ";
                     cin >> className;
                     cout << "Enter the name of the attribute: ";
                     cin >> attributeName;
                     cout << "Enter new name of attribute: ";
                     cin >> attributeName2;
+
                     data.changeAttributeName(className, attributeName, attributeName2);
                     cout << endl << "Attribute " << attributeName << " renamed to " << attributeName2 << endl << endl;
                     subLoop = false;
                 }
                 // Go back
                 else if (userChoice == "4") {
-                    // Exits subroutine, goes back to main routine
+                    // Exits subroutine to go back to main routine
                     subLoop = false;
                 }
                 // Invalid choice
                 else {
-                    // Show error, reset user choice
                     cout << "Invalid choice" << endl << endl;
                     userChoice = "2";
                 }
@@ -240,7 +251,6 @@ void CLI::displayCLI ()
                 cout << "[2] Remove" << endl;
                 cout << "[3] Back" << endl;
 
-                // Store user option
                 cout << endl << "Choice: ";
                 cin >> userChoice;
                 cout << endl;
@@ -250,38 +260,39 @@ void CLI::displayCLI ()
 
                 // Add relationship
                 if (userChoice == "1") {
-                    // Display all classes
+                    // Display all classes for user clarity
                     displayDiagram(false, false);
-                    // Prompt name of source and destination and removes relationship
+
                     cout << "Enter the name of the source: " << endl;
                     cin >> source;
                     cout << "Enter the name of the destination: " << endl;
                     cin >> destination;
+
                     data.addRelationship(source, destination);
                     cout << endl <<"Relationship added between " << source << " and " << destination << endl << endl;
                     subLoop = false;
                 }
                 // Remove relationship
                 else if (userChoice == "2") {
-                    // Display all classes and relationships
+                    // Display all classes and relationships for user clarity
                     displayDiagram(false, true);
-                    // Prompt name of source and destination and removes relationship
+
                     cout << "Enter the name of the source: " << endl;
                     cin >> source;
                     cout << "Enter the name of the destination: " << endl;
                     cin >> destination;
+
                     data.deleteRelationship(source, destination);
                     cout << endl << "Relationship deleted between " << source << " and " << destination << endl << endl;
                     subLoop = false;
                 } 
                 // Go back
                 else if (userChoice == "3") {
-                    // Exits subroutine, goes back to main routine
+                    // Exits subroutine to go back to main routine
                     subLoop = false;
                 }
                 // Invalid choice
                 else {
-                    // Show error, reset user choice
                     cout << "Invalid choice!" << endl << endl;
                     userChoice = "3";
                 }
@@ -295,7 +306,6 @@ void CLI::displayCLI ()
                 cout << "[2] Diagram" << endl;
                 cout << "[3] Back" << endl;
 
-                // Store user option
                 cout << endl << "Choice: ";
                 cin >> userChoice;
                 cout << endl;
@@ -305,11 +315,12 @@ void CLI::displayCLI ()
 
                 // Display single class
                 if (userChoice == "1") {
-                    // Display class names
+                    // Display class names for user clarity
                     displayDiagram (false, false); 
-                    // Prompt class name
+
                     cout << "Enter name of class:" << endl;
                     cin >> name;
+
                     displayClass(name);
                     cout << endl << "Enter anything to continue..." << endl;
                     cin >> name; // Pause for input
@@ -319,6 +330,7 @@ void CLI::displayCLI ()
                 // Display all information
                 else if (userChoice == "2") {
                     displayDiagram (true, true); 
+                    
                     cout << "Enter anything to continue..." << endl;
                     cin >> name; // Pause for input
                     cout << endl;                  
@@ -326,12 +338,11 @@ void CLI::displayCLI ()
                 } 
                 // Go back
                 else if (userChoice == "3") {
-                    // Exits subroutine, goes back to main routine
+                    // Exits subroutine to go back to main routine
                     subLoop = false;
                 }
                 // Invalid choice
                 else {
-                    // Show error, reset user choice
                     cout << "Invalid choice!" << endl << endl;
                     userChoice = "4";
                 }
@@ -341,8 +352,9 @@ void CLI::displayCLI ()
             else if (userChoice == "5") {
                 // Saves UML diagram to a JSON file in the same directory as the executable
                 cout << "Name of file: ";
-                std::string fileName;
-                std::cin >> fileName;
+                string fileName;
+                cin >> fileName;
+
                 UMLFile file(fileName + ".json");
                 file.save(data);
                 cout << "Your file has been saved" << endl;
@@ -353,8 +365,9 @@ void CLI::displayCLI ()
             else if (userChoice == "6") {
                 // Ask for name of file, and then load UML data given the proper format
                 cout << "Name of file: ";
-                std::string fileName;
-                std::cin >> fileName;
+                string fileName;
+                cin >> fileName;
+
                 UMLFile file(fileName + ".json");
                 data = file.load();
                 cout << "Your file has been loaded" << endl;
@@ -373,6 +386,7 @@ void CLI::displayCLI ()
                     myfile.close();
                 }
                 else cout << "Unable to open file";
+                
                 cout << endl << "Enter anything to continue..." << endl;
                 cin >> line; // Pause for input
                 cout << endl; 
@@ -381,13 +395,13 @@ void CLI::displayCLI ()
 
             // Exits the program
             else if (userChoice == "8") {
+                cout << "Exiting program..." << endl << endl;
                 subLoop = false;
                 mainLoop = false;
             }
 
             // Invalid choice
             else {
-                // Show error, reset user choice and break loop
                 cout << "Invalid choice!" << endl << endl;
                 userChoice = "";
                 subLoop = false;
@@ -419,8 +433,8 @@ void CLI::displayDiagram (bool displayAttribute, bool displayRelationship)
         // Don't cause spacing within loop if only showing classes
         if (displayAttribute || displayRelationship) cout << endl;
     }
-    // Display single line break if only showing classes
-    if (!displayAttribute && !displayRelationship) cout << endl;
+    // Display single line break if only showing classes. but NOT if classes are empty
+    if (!displayAttribute && !displayRelationship && data.getClasses().size() > 0) cout << endl;
 }
 
 void CLI::displayClass (string className) 

--- a/CLI.hpp
+++ b/CLI.hpp
@@ -59,14 +59,14 @@ void CLI::displayCLI ()
     while (mainLoop) {
         // Main prompt: prompts user for options.
         cout << "Choose an option:"<< endl;
-        cout << "Class [0]" << endl;
-        cout << "Attribute [1]" << endl;
-        cout << "Relationship [2]" << endl;
-        cout << "List [3]" << endl;
-        cout << "Save [4]" << endl;
-        cout << "Load [5]" << endl;
-        cout << "Help [6]" << endl;
-        cout << "Exit [7]" << endl;
+        cout << "[0] Class" << endl;
+        cout << "[1] Attribute" << endl;
+        cout << "[2] Relationship" << endl;
+        cout << "[3] List" << endl;
+        cout << "[4] Save" << endl;
+        cout << "[5] Load" << endl;
+        cout << "[6] Help" << endl;
+        cout << "[7] Exit" << endl;
 
         // store user option
         cout << endl << "Choice: ";
@@ -81,10 +81,10 @@ void CLI::displayCLI ()
             if(userChoice == "0") {
                 // Lists operations for modifying classes
                 cout << "Choose an option:"<< endl;
-                cout << "Add [0]" << endl;
-                cout << "Remove [1]" << endl;
-                cout << "Rename [2]" << endl;
-                cout << "Back [3]" << endl;
+                cout << "[0] Add" << endl;
+                cout << "[1] Remove" << endl;
+                cout << "[2] Rename" << endl;
+                cout << "[3] Back" << endl;
 
                 // store user option
                 cout << endl << "Choice: ";
@@ -138,10 +138,10 @@ void CLI::displayCLI ()
             else if(userChoice == "1") {
                 // Lists operations for modifying attributes
                 cout << "Choose an option:"<< endl;
-                cout << "Add [0]" << endl;
-                cout << "Remove [1]" << endl;
-                cout << "Rename [2]" << endl;
-                cout << "Back [3]" << endl;
+                cout << "[0] Add" << endl;
+                cout << "[1] Remove" << endl;
+                cout << "[2] Rename" << endl;
+                cout << "[3] Back" << endl;
 
                 // store user option
                 cout << endl << "Choice: ";
@@ -204,9 +204,9 @@ void CLI::displayCLI ()
             else if(userChoice == "2") {
                 // Lists operations for modifying relationships
                 cout << "Choose an option:"<< endl;
-                cout << "Add [0]" << endl;
-                cout << "Remove [1]" << endl;
-                cout << "Back [2]" << endl;
+                cout << "[0] Add" << endl;
+                cout << "[1] Remove" << endl;
+                cout << "[2] Back" << endl;
 
                 // store user option
                 cout << endl << "Choice: ";
@@ -254,9 +254,9 @@ void CLI::displayCLI ()
             else if(userChoice == "3") {
                 // Lists operations for viewing information within the diagram
                 cout << "Choose an option:"<< endl;
-                cout << "Class [0]" << endl;
-                cout << "Diagram [1]" << endl;
-                cout << "Back [2]" << endl;
+                cout << "[0] Class" << endl;
+                cout << "[1] Diagram" << endl;
+                cout << "[2] Back" << endl;
 
                 // store user option
                 cout << endl << "Choice: ";

--- a/UMLAttribute.hpp
+++ b/UMLAttribute.hpp
@@ -33,7 +33,7 @@ class UMLAttribute
 		UMLAttribute(string newAttribute);
 
 		// Grab name of the given attribute
-		string getAttributeName();
+		string getAttributeName() const;
 
 		// Change name of the given attribute
 		void changeName(string newAttributeName);
@@ -45,7 +45,7 @@ UMLAttribute::UMLAttribute(string newAttribute)
 {
 }
 
-string UMLAttribute::getAttributeName()
+string UMLAttribute::getAttributeName() const
 {
 	return attributeName;
 }

--- a/UMLClass.hpp
+++ b/UMLClass.hpp
@@ -28,32 +28,30 @@ class UMLClass
 		vector<UMLAttribute> classAttributes;
 
 	public:
-		// Params: newClass (name of class)
 		// Constructor for class object without attributes
 		UMLClass(string newClass);
 
-		// Params: newClass (name of class), attributes (vector of attributes)
 		// Constructor for class object with attributes
 		UMLClass(string newClass, const std::vector<UMLAttribute>& attributes);
 
 		// Grab name from given class object
 		string getName() const;
 
-		// Params: string newClassName (name of class to be changed)
 		// Change name of given class object
 		void changeName(string newClassName);
 
-		// Params: UMLAttribute newAttribute (attribute object to be added)
 		// Adds attribute to attribute vector
 		void addAttribute(UMLAttribute newAttribute);
 
-		// Params: string attributeName (name of attribute to be deleted)
+		//Changes name of attribute within class
+		void changeAttributeName(string oldAttributeName, string newAttributeName);
+
 		// Removes attribute from attribute vector
 		vector<UMLAttribute>::iterator deleteAttribute(string attributeName);
 
-		// Params: string attributeName (name of attribute to be found) 
 		// Finds attribute within attribute vector
 		vector<UMLAttribute>::iterator findAttribute(string attributeName);
+
 
 		// Returns vector of attributes 
 		vector<UMLAttribute> getAttributes() const;
@@ -83,6 +81,11 @@ void UMLClass::changeName(string newClassName)
 void UMLClass::addAttribute(UMLAttribute newAttribute) 
 {
 	classAttributes.push_back(newAttribute);
+}
+
+void UMLClass::changeAttributeName(string oldAttributeName, string newAttributeName)
+{
+	(*findAttribute(oldAttributeName)).changeName(newAttributeName);
 }
 
 vector<UMLAttribute>::iterator UMLClass::deleteAttribute(string attributeName) 

--- a/UMLClass.hpp
+++ b/UMLClass.hpp
@@ -52,7 +52,6 @@ class UMLClass
 		// Finds attribute within attribute vector
 		vector<UMLAttribute>::iterator findAttribute(string attributeName);
 
-
 		// Returns vector of attributes 
 		vector<UMLAttribute> getAttributes() const;
 };

--- a/UMLClass.hpp
+++ b/UMLClass.hpp
@@ -56,7 +56,7 @@ class UMLClass
 		vector<UMLAttribute>::iterator findAttribute(string attributeName);
 
 		// Returns vector of attributes 
-		vector<UMLAttribute> getAttributes();
+		vector<UMLAttribute> getAttributes() const;
 };
 
 UMLClass::UMLClass(string newClass) 
@@ -108,7 +108,7 @@ vector<UMLAttribute>::iterator UMLClass::findAttribute(string attributeName)
 	return classAttributes.end();
 }
 
-vector<UMLAttribute> UMLClass::getAttributes() 
+vector<UMLAttribute> UMLClass::getAttributes() const
 {
 	return classAttributes;
 }

--- a/UMLData.hpp
+++ b/UMLData.hpp
@@ -205,7 +205,7 @@ void UMLData::deleteClass(string name)
 void UMLData::changeClassName(string oldName, string newName)
 {
     if (findClass(newName) >= 0)
-        throw "New name already exists";
+        throw "Class name already exists";
     getClass(oldName).changeName(newName);
 }
 
@@ -261,7 +261,7 @@ UMLClass& UMLData::getClass(string name)
 {
     int loc = findClass(name);
     if (loc < 0)
-        throw "Name not found";
+        throw "Class not found";
     return classes[loc];
 }
 
@@ -277,7 +277,7 @@ void UMLData::addRelationship(const UMLRelationship& relIn)
 {
     int loc = findRelationship(relIn.getSource(), relIn.getDestination());
     if (loc >= 0)
-        throw "Relationship already exists";
+        throw "New relationship already exists";
 
     relationships.push_back(relIn); 
 }

--- a/UMLData.hpp
+++ b/UMLData.hpp
@@ -43,49 +43,41 @@ class UMLData
         //returns vector of all relationships
         vector<UMLRelationship> getRelationships() const;
 
-        //params: classIn
         //takes in class and adds it to vector
         void addClass(const UMLClass& classIn);
 
-        //params: string name
         //takes in string name and creates class and adds to classes vector
         void addClass(string name);
 
-        //params: string name, vector<UMLAttributes> attributes
         //takes in name and vector of attributes and creates class and adds to vector of classes
         void addClass(string name, vector<UMLAttribute> attributes);
 
-        //params: string srcName, destName
         //takes in src string and dest string, creates relationship and adds to relationships vector
         void addRelationship(string srcName, string destName);
         
-        //params: std:string className
         //takes in className string and returns a vector of all the relationshps associated with that class
         vector<UMLRelationship> getRelationshipsByClass(string className);
 
-        //params: string srcName, string destName
         //deletes relationshp based on two strings
         void deleteRelationship(string srcName, string destName);
 
-        //params: string name
         //deletes a class by string in the classes vector
         void deleteClass(string name);
 
-        //params: string oldName, string newName
         //changes class name from old name and new name
         void changeClassName(string oldName, string newName);
 
-        //params string className
         //gets class attributes for a className class and returns them in a vector
         vector<UMLAttribute> getClassAttributes(string className);
 
-        //params string className, UMLAttribute attribute
         //adds class attribute to specified className
         void addClassAttribute(string className, UMLAttribute attribute);
 
-        //params: string className, string attribute name
         //removes className class attribute by the name
         void removeClassAttribute(string className, string attributeName);
+
+        //removes className class attribute by the name
+        void changeAttributeName(string className, string oldAttributeName, string newAttributeName);
 
     private:
 
@@ -230,6 +222,11 @@ void UMLData::addClassAttribute(string className, UMLAttribute attribute)
 void UMLData::removeClassAttribute(string className, string attributeName)
 {
     getClass(className).deleteAttribute(attributeName);
+}
+
+void UMLData::changeAttributeName(string className, string oldAttributeName, string newAttributeName)
+{
+    getClass(className).changeAttributeName(oldAttributeName, newAttributeName);
 }
 
 int UMLData::findClass(string name)

--- a/help.txt
+++ b/help.txt
@@ -6,51 +6,51 @@ operations for Class, input a 0 and press Enter to enter it.
 
 UML++ has the following hierarchy for its command-line interface:
 
-- [0] Class: Lists operations for modifying classes.
-    - [0] Add: Prompts for a class name. If the class does not already exist
+- [1] Class: Lists operations for modifying classes.
+    - [1] Add: Prompts for a class name. If the class does not already exist
                and is valid, the class will be inserted into the diagram.
-    - [1] Remove: Prompts for a class name. If the class exists, the class will
+    - [2] Remove: Prompts for a class name. If the class exists, the class will
                   be removed from the UML class diagram.
-    - [2] Rename: Prompts for a class name. If the class exists and the new 
+    - [3] Rename: Prompts for a class name. If the class exists and the new 
                   name is valid, the class will have its name modified to the
                   new name prompted.
-    - [3] Back: Returns back to the main set of commands.
+    - [4] Back: Returns back to the main set of commands.
     
-- [1] Attribute: Lists operations for modifying attributes.
-    - [0] Add: Prompts for a class and an attribute name. If the class exists
+- [2] Attribute: Lists operations for modifying attributes.
+    - [1] Add: Prompts for a class and an attribute name. If the class exists
                and the attribute does not already exist in the class and is 
                valid, it will be inserted into the class.
-    - [1] Remove: Prompts for a class and an attribute name. If the class 
+    - [2] Remove: Prompts for a class and an attribute name. If the class 
                   exists alongside the attribute, the attribute will be 
                   removed.
-    - [2] Rename: Prompts for a class and an attribute name. If the class 
+    - [3] Rename: Prompts for a class and an attribute name. If the class 
                   exists alongside the attribute, and the attribute name is 
                   valid, the attribute will be renamed.
-    - [3] Back: Returns back to the main set of commands.
+    - [4] Back: Returns back to the main set of commands.
     
-- [2] Relationship: Lists operations for modifying relationships.
-    - [0] Add: Prompts for a source class and a destination class. If both 
+- [3] Relationship: Lists operations for modifying relationships.
+    - [1] Add: Prompts for a source class and a destination class. If both 
                classes exist and the relationship doesn't already exist, a new
                relationship is made.
-    - [1] Remove: Prompts for a source class and a destination class. If the 
+    - [2] Remove: Prompts for a source class and a destination class. If the 
                   relationship exists, it will be removed.
-    - [2] Back: Returns back to the main set of commands.
+    - [3] Back: Returns back to the main set of commands.
     
-- [3] List: Lists operations for viewing information within the diagram.
-    - [0] Class: Prompts for a class name. If the class exists, information 
+- [4] List: Lists operations for viewing information within the diagram.
+    - [1] Class: Prompts for a class name. If the class exists, information 
                  about the class, its attributes, and its relationships will 
                  be displayed.
-    - [1] Diagram: Displays all information for all classes, alongside their 
+    - [2] Diagram: Displays all information for all classes, alongside their 
                    attributes and relationships.
-    - [2] Back: Returns back to the main set of commands.
+    - [3] Back: Returns back to the main set of commands.
     
-- [4] Save: Saves your UML diagram to a JSON file in the same directory as the
+- [5] Save: Saves your UML diagram to a JSON file in the same directory as the
             executable.
 
-- [5] Load: Prompts for a directory. If the directory exists, a UML diagram 
+- [6] Load: Prompts for a directory. If the directory exists, a UML diagram 
             made previously by this program will be loaded for modification.
 
-- [6] Help: Loads this help file into the console.
+- [7] Help: Loads this help file into the console.
 
-- [7] Exit: Exits the program. If the UML class diagram is not saved 
+- [8] Exit: Exits the program. If the UML class diagram is not saved 
             beforehand, data will be lost.

--- a/help.txt
+++ b/help.txt
@@ -6,50 +6,51 @@ operations for Class, input a 0 and press Enter to enter it.
 
 UML++ has the following hierarchy for its command-line interface:
 
-- Class [0]: Lists operations for modifying classes.
-    - Add [0]: Prompts for a class name. If the class does not already exist
+- [0] Class: Lists operations for modifying classes.
+    - [0] Add: Prompts for a class name. If the class does not already exist
                and is valid, the class will be inserted into the diagram.
-    - Remove [1]: Prompts for a class name. If the class exists, the class will
+    - [1] Remove: Prompts for a class name. If the class exists, the class will
                   be removed from the UML class diagram.
-    - Rename [2]: Prompts for a class name. If the class exists and the new 
+    - [2] Rename: Prompts for a class name. If the class exists and the new 
                   name is valid, the class will have its name modified to the
                   new name prompted.
-    - Back [3]: Returns back to the main set of commands.
+    - [3] Back: Returns back to the main set of commands.
     
-- Attribute [1]: Lists operations for modifying attributes.
-    - Add [0]: Prompts for a class and an attribute name. If the class exists
+- [1] Attribute: Lists operations for modifying attributes.
+    - [0] Add: Prompts for a class and an attribute name. If the class exists
                and the attribute does not already exist in the class and is 
                valid, it will be inserted into the class.
-    - Remove [1]: Prompts for a class and an attribute name. If the class 
+    - [1] Remove: Prompts for a class and an attribute name. If the class 
                   exists alongside the attribute, the attribute will be 
                   removed.
-    - Rename [2]: Prompts for a class and an attribute name. If the class 
+    - [2] Rename: Prompts for a class and an attribute name. If the class 
                   exists alongside the attribute, and the attribute name is 
                   valid, the attribute will be renamed.
-    - Back [3]: Returns back to the main set of commands.
+    - [3] Back: Returns back to the main set of commands.
     
-- Relationship [2]: Lists operations for modifying relationships.
-    - Add [0]: Prompts for a source class and a destination class. If both 
+- [2] Relationship: Lists operations for modifying relationships.
+    - [0] Add: Prompts for a source class and a destination class. If both 
                classes exist and the relationship doesn't already exist, a new
                relationship is made.
-    - Remove [1]: Prompts for a source class and a destination class. If the 
+    - [1] Remove: Prompts for a source class and a destination class. If the 
                   relationship exists, it will be removed.
-    - Back [3]: Returns back to the main set of commands.
+    - [2] Back: Returns back to the main set of commands.
     
-- List [3]: Lists operations for viewing information within the diagram.
-    - Class [0]: Prompts for a class name. If the class exists, information 
+- [3] List: Lists operations for viewing information within the diagram.
+    - [0] Class: Prompts for a class name. If the class exists, information 
                  about the class, its attributes, and its relationships will 
                  be displayed.
-    - Diagram [1]: Displays all information for all classes, alongside their 
+    - [1] Diagram: Displays all information for all classes, alongside their 
                    attributes and relationships.
+    - [2] Back: Returns back to the main set of commands.
     
-- Save [4]: Saves your UML diagram to a JSON file in the same directory as the
+- [4] Save: Saves your UML diagram to a JSON file in the same directory as the
             executable.
 
-- Load [5]: Prompts for a directory. If the directory exists, a UML diagram 
+- [5] Load: Prompts for a directory. If the directory exists, a UML diagram 
             made previously by this program will be loaded for modification.
 
-- Help [6]: Loads this help file into the console.
+- [6] Help: Loads this help file into the console.
 
-- Exit [7]: Exits the program. If the UML class diagram is not saved 
+- [7] Exit: Exits the program. If the UML class diagram is not saved 
             beforehand, data will be lost.


### PR DESCRIPTION
Significant changes made before error checking is implemented, including

- At certain points in the interface, the CLI now shows what classes, attributes, and relationships are available to access.
- Numbers to be input are now listed started from 1 instead of starting from 0.
- Renaming of attributes now properly renames instead of deleting the old one and then adding a new one with a different name.
- CLI output spacing is now generally consistent.
- Various formatting adjustments around other parts of the code.