### PR TITLE
Loop Change & Minor Adjustments

### DIFF
--- a/CLI.hpp
+++ b/CLI.hpp
@@ -70,14 +70,11 @@ class CLI
 // Displays CLI using a large loop routine.
 void CLI::displayCLI ()
 {
-    // Start default state of loops
-    mainLoop = true;
-    subLoop = false;
 
     cout << "Welcome to UML++!" << endl << endl;
-
     // Primary display routine
     while (mainLoop) {
+        subLoop = true;
         // Main prompt: prompts user for options.
         cout << "Choose an option:" << endl;
         cout << "[1] Class" << endl;
@@ -92,11 +89,9 @@ void CLI::displayCLI ()
         cout << endl << "Choice: ";
         cin >> userChoice;
         cout << endl;
-
         // Start subloop
-        subLoop = true;
-
-        while (subLoop) { 
+        while (subLoop) {
+            subLoop = false;
             // Class subroutine
             if(userChoice == "1") {
                 // Lists operations for modifying classes
@@ -123,7 +118,6 @@ void CLI::displayCLI ()
                     // Prevent success message if error was caught
                     if(errorStatus == false) cout << endl << "Class named " << name << " added" << endl << endl;
                     else errorStatus = false;
-                    subLoop = false;
                 }
                 // Remove class
                 else if (userChoice == "2") {
@@ -138,7 +132,6 @@ void CLI::displayCLI ()
                     // Prevent success message if error was caught
                     if(errorStatus == false) cout << endl << "Class named " << name << " removed" << endl << endl;
                     else errorStatus = false;
-                    subLoop = false;
                 } 
                 // Rename class
                 else if (userChoice == "3") {
@@ -156,17 +149,16 @@ void CLI::displayCLI ()
                     // Prevent success message if error was caught
                     if(errorStatus == false) cout << endl << "Class named " << name << " renamed to " << name2 << endl << endl;
                     else errorStatus = false;
-                    subLoop = false;
                 }
                 // Go back
                 else if (userChoice == "4") {
                     // Exits subroutine to go back to main routine
-                    subLoop = false;
                 }
                 // Invalid choice
                 else {
                     cout << "Invalid choice!" << endl << endl;
                     userChoice = "1";
+                    subLoop = true;
                 }
             }
 
@@ -199,7 +191,6 @@ void CLI::displayCLI ()
                     ERR_CATCH(data.addClassAttribute(className, attributeName));
                     if (errorStatus == false) cout << endl << "Attribute " << attributeName << " added to " << className << endl << endl;
                     else errorStatus = false;
-                    subLoop = false;
 
                 }
                 // Remove attribute
@@ -215,7 +206,6 @@ void CLI::displayCLI ()
                     ERR_CATCH(data.removeClassAttribute(className, attributeName));
                     if (errorStatus == false) cout << endl << "Attribute " << attributeName << " removed from " << className << endl << endl;
                     else errorStatus = false;
-                    subLoop = false;
                 } 
                 // Rename attribute
                 else if (userChoice == "3") {
@@ -232,17 +222,16 @@ void CLI::displayCLI ()
                     ERR_CATCH(data.changeAttributeName(className, attributeName, attributeName2));
                     if (errorStatus == false) cout << endl << "Attribute " << attributeName << " renamed to " << attributeName2 << endl << endl;
                     else errorStatus = false;
-                    subLoop = false;
                 }
                 // Go back
                 else if (userChoice == "4") {
                     // Exits subroutine to go back to main routine
-                    subLoop = false;
                 }
                 // Invalid choice
                 else {
                     cout << "Invalid choice" << endl << endl;
                     userChoice = "2";
+                    subLoop = true;
                 }
             }
 
@@ -273,7 +262,6 @@ void CLI::displayCLI ()
 
                     ERR_CATCH(data.addRelationship(source, destination));
                     if (errorStatus == false) cout << endl <<"Relationship added between " << source << " and " << destination << endl << endl;
-                    else subLoop = false;
                 }
                 // Remove relationship
                 else if (userChoice == "2") {
@@ -288,17 +276,16 @@ void CLI::displayCLI ()
                     ERR_CATCH(data.deleteRelationship(source, destination));
                     if (errorStatus == false) cout << endl << "Relationship deleted between " << source << " and " << destination << endl << endl;
                     else errorStatus = false;
-                    subLoop = false;
                 } 
                 // Go back
                 else if (userChoice == "3") {
                     // Exits subroutine to go back to main routine
-                    subLoop = false;
                 }
                 // Invalid choice
                 else {
                     cout << "Invalid choice!" << endl << endl;
                     userChoice = "3";
+                    subLoop = true;
                 }
             }
 
@@ -329,7 +316,6 @@ void CLI::displayCLI ()
                     cout << endl << "Enter anything to continue..." << endl;
                     cin >> name; // Pause for input
                     cout << endl; 
-                    subLoop = false;
                 }
                 // Display all information
                 else if (userChoice == "2") {
@@ -338,17 +324,16 @@ void CLI::displayCLI ()
                     cout << "Enter anything to continue..." << endl;
                     cin >> name; // Pause for input
                     cout << endl;                  
-                    subLoop = false;
                 } 
                 // Go back
                 else if (userChoice == "3") {
                     // Exits subroutine to go back to main routine
-                    subLoop = false;
                 }
                 // Invalid choice
                 else {
                     cout << "Invalid choice!" << endl << endl;
                     userChoice = "4";
+                    subLoop = true;
                 }
             }
 
@@ -362,7 +347,6 @@ void CLI::displayCLI ()
                 UMLFile file(fileName + ".json");
                 file.save(data);
                 cout << "Your file has been saved" << endl;
-                subLoop = false;
             }
 
             // Load UML subroutine
@@ -382,7 +366,6 @@ void CLI::displayCLI ()
                 }
                 if (errorStatus == false) cout << "Your file has been loaded" << endl;
                 else errorStatus = false;
-                subLoop = false;
             }
 
             // Help subroutine
@@ -401,13 +384,11 @@ void CLI::displayCLI ()
                 cout << endl << "Enter anything to continue..." << endl;
                 cin >> line; // Pause for input
                 cout << endl; 
-                subLoop = false;
             }
 
             // Exits the program
             else if (userChoice == "8") {
                 cout << "Exiting program..." << endl << endl;
-                subLoop = false;
                 mainLoop = false;
             }
 
@@ -415,7 +396,6 @@ void CLI::displayCLI ()
             else {
                 cout << "Invalid choice!" << endl << endl;
                 userChoice = "";
-                subLoop = false;
             }
         }  
     } 


### PR DESCRIPTION
- Corrections to the CLI loop that require less redundant boolean toggling for moving in and out of the routines.
- Small comment fixes ('subroutines' instead of 'subrountines' in CLI.hpp, minor commenting to explain CLI loop changes)
- Fixed display of load error for when an improper filename is given.