### PR TITLE
Relationship Types

### DIFF
--- a/CLI.cpp
+++ b/CLI.cpp
@@ -196,7 +196,8 @@ void CLI::displayCLI ()
                 cout << "Choose an option:" << endl;
                 cout << "[1] Add" << endl;
                 cout << "[2] Remove" << endl;
-                cout << "[3] Back" << endl;
+                cout << "[3] Modify Type" << endl;
+                cout << "[4] Back" << endl;
 
                 cout << endl << "Choice: ";
                 cin >> userChoice;
@@ -257,8 +258,41 @@ void CLI::displayCLI ()
                     if (errorStatus == false) cout << endl << "Relationship deleted between " << source << " and " << destination << endl << endl;
                     else errorStatus = false;
                 } 
-                // Go back
                 else if (userChoice == "3") {
+                    // Display all classes and relationships for user clarity
+                    displayDiagram(false, true);
+
+                    cout << "Enter the name of the source: " << endl;
+                    cin >> source;
+                    cout << "Enter the name of the destination: " << endl;
+                    cin >> destination;
+                    
+                    // Loop to grab string of type and convert into integer
+                    while (typeLoop) {
+                        typeLoop = false;
+                        cout << "Enter the new type of relationship:" << endl;
+                        cout << "[1] Aggregation" << endl;
+                        cout << "[2] Composition" << endl;
+                        cout << "[3] Generalization" << endl;
+                        cout << "[4] Realization" << endl;
+                        cin >> stringType;
+                        if (stringType == "1" || stringType == "2" || stringType == "3" || stringType == "4") {
+                            // Type is enum starting from 0, so subtract by 1
+                            type = std::stoi(stringType) - 1;
+                        }
+                        else {
+                            cout << "Invalid choice!" << endl << endl;
+                            typeLoop = true;
+                        }
+                    }
+
+                    ERR_CATCH(data.changeRelationshipType(source, destination, type));
+                    if (errorStatus == false) cout << endl << "Relationship between " << source << " and " << destination
+                        << " changed to type " << data.getRelationshipType(source, destination) << endl << endl;
+                    else errorStatus = false;
+                }
+                // Go back
+                else if (userChoice == "4") {
                     // Exits subroutine to go back to main routine
                 }
                 // Invalid choice

--- a/CLI.cpp
+++ b/CLI.cpp
@@ -229,7 +229,8 @@ void CLI::displayCLI ()
                         cout << "[4] Realization" << endl;
                         cin >> stringType;
                         if (stringType == "1" || stringType == "2" || stringType == "3" || stringType == "4") {
-                            type = std::stoi(stringType);
+                            // Type is enum starting from 0, so subtract by 1
+                            type = std::stoi(stringType) - 1;
                         }
                         else {
                             cout << "Invalid choice!" << endl << endl;

--- a/CLI.cpp
+++ b/CLI.cpp
@@ -388,6 +388,8 @@ void CLI::displayCLI ()
     } 
 }
 
+// Displays information about classes within the diagram.
+// Has conditional booleans to optionally display attributes and relationships.
 void CLI::displayDiagram (bool displayAttribute, bool displayRelationship) 
 {
     vector<UMLClass> classes = data.getClasses();
@@ -406,6 +408,7 @@ void CLI::displayDiagram (bool displayAttribute, bool displayRelationship)
             for (UMLRelationship rel : data.getRelationshipsByClass(umlclass.getName()))
             {
                 cout << rel.getSource().getName() << " => " << rel.getDestination().getName() << endl;
+                cout << "Type: " << data.getRelationshipType(rel.getSource().getName(), rel.getDestination().getName()) << endl;
             }
         }
         // Don't cause spacing within loop if only showing classes
@@ -415,6 +418,7 @@ void CLI::displayDiagram (bool displayAttribute, bool displayRelationship)
     if (!displayAttribute && !displayRelationship && data.getClasses().size() > 0) cout << endl;
 }
 
+// Displays information about a single class with the name className.
 void CLI::displayClass (string className) 
 {
     // Grab copy of class in order to display attributes
@@ -429,8 +433,9 @@ void CLI::displayClass (string className)
     // Find relationships based on name of the class
     cout << "Relationships:" << endl;
     vector<UMLRelationship> relationshipList = data.getRelationshipsByClass(className);
-    for(UMLRelationship relationship : relationshipList)
+    for(UMLRelationship rel : relationshipList)
     {
-        cout << relationship.getSource().getName() << " => " << relationship.getDestination().getName() << endl;
+        cout << rel.getSource().getName() << " => " << rel.getDestination().getName() << endl;
+        cout << "Type: " << data.getRelationshipType(rel.getSource().getName(), rel.getDestination().getName()) << endl;
     }
 }

--- a/CLI.cpp
+++ b/CLI.cpp
@@ -19,6 +19,7 @@ void CLI::displayCLI ()
 
     // Primary display routine
     while (mainLoop) {
+        errorStatus = false;
         // Main prompt: prompts user for options.
         cout << "Choose an option:" << endl;
         cout << "[1] Class" << endl;
@@ -141,7 +142,6 @@ void CLI::displayCLI ()
                     if (errorStatus == false) cout << endl << "Attribute " << attributeName << " added to " << className << endl << endl;
                     else errorStatus = false;
                     subLoop = false;
-
                 }
                 // Remove attribute
                 else if (userChoice == "2") {
@@ -199,8 +199,12 @@ void CLI::displayCLI ()
                 cin >> userChoice;
                 cout << endl;
 
-                // Class name representing source and destination
-                string source, destination;
+                // String representing source, destination, type
+                string source, destination, stringType;
+                // Integer representing type 
+                int type;
+                // Boolean to control type loop
+                bool typeLoop = true;
 
                 // Add relationship
                 if (userChoice == "1") {
@@ -211,10 +215,27 @@ void CLI::displayCLI ()
                     cin >> source;
                     cout << "Enter the name of the destination: " << endl;
                     cin >> destination;
-
-                    ERR_CATCH(data.addRelationship(source, destination));
-                    if (errorStatus == false) cout << endl <<"Relationship added between " << source << " and " << destination << endl << endl;
-                    else subLoop = false;
+                    while (typeLoop) {
+                        typeLoop = false;
+                        cout << "Choose the type of relationship:" << endl;
+                        cout << "[1] Aggregation" << endl;
+                        cout << "[2] Composition" << endl;
+                        cout << "[3] Generalization" << endl;
+                        cout << "[4] Realization" << endl;
+                        cin >> stringType;
+                        if (stringType == "1" || stringType == "2" || stringType == "3" || stringType == "4") {
+                            type = std::stoi(stringType);
+                        }
+                        else {
+                            cout << "Invalid choice!" << endl << endl;
+                            typeLoop = true;
+                        }
+                    }
+                    ERR_CATCH(data.addRelationship(source, destination, type));
+                    if (errorStatus == false) cout << endl << "Relationship added between " << source << " and " << destination
+                        << " of type " << data.getRelationshipType(source, destination) << endl << endl;
+                    else errorStatus = false;
+                    subLoop = false;
                 }
                 // Remove relationship
                 else if (userChoice == "2") {

--- a/Tests.cpp
+++ b/Tests.cpp
@@ -113,29 +113,158 @@ TEST(UMLDataAttributeTest, RemovingNonExistantAttribute)
     ASSERT_ANY_THROW(data.removeClassAttribute("test", "hastestt"));
 }
 
-/*
 TEST(UMLDataRelationshipTest, AddingRelationshipWorks) 
 {
-    bool haveRelationship;
-    haveRelationship == false;
+    bool haveRelationship = false;
     UMLData data;
     data.addClass("test");
     data.addClass("test1");
-    vector<UMLRelationship> rel = data.getRelationships();
+    // Relationship type doesn't matter for this test
+    data.addRelationship("test", "test1", 0);
     
-    data.addRelationship("test", "test1");
-   
+    vector<UMLRelationship> rel = data.getRelationships();
+   // Loop through vector to find proper relationship
     for(auto i = rel.begin(); i != rel.end(); ++i){
-        if(&(rel[i].getSource()) == "test1"){
-            haveRelationship == true;
+        // Check and see if the valid relationship was added
+        if(i->getSource().getName() == "test" && 
+        i->getDestination().getName() == "test1" && 
+        i->getType() == aggregation){
+            haveRelationship = true;
         }
-        else if(&(rel[i].getDestination()) == "test1"){
-            haveRelationship == true;
-        }
-   }
-    ASSERT_EQ(haveRelationship, true); 
+    }
+
+    // Relationship should exist
+    ASSERT_EQ(haveRelationship, true);
+    // Only one relationship should have been added
+    ASSERT_EQ(rel.size(), std::size_t(1));
 }
-*/
+
+TEST(UMLDataRelationshipTest, AddingInvalidType) 
+{
+    UMLData data;
+
+    data.addClass("test");
+    data.addClass("test1");
+    // Relationship type shouldn't be over 3
+    ASSERT_ANY_THROW(data.addRelationship("test", "test1", 4));
+
+    data.addClass("test2");
+    data.addClass("test3");
+    // Relationship type shouldn't be less than 0
+    ASSERT_ANY_THROW(data.addRelationship("test2", "test3", -1));
+}
+
+TEST(UMLDataRelationshipTest, AddingSelfInheritance) 
+{
+    UMLData data;
+
+    data.addClass("test");
+    data.addClass("test1");
+    // Cannot have self-generalization or self-realization
+    ASSERT_ANY_THROW(data.addRelationship("test", "test", 2));
+    ASSERT_ANY_THROW(data.addRelationship("test1", "test1", 3));
+}
+
+TEST(UMLDataRelationshipTest, AddingMultipleCompositions) 
+{
+    UMLData data;
+
+    data.addClass("test");
+    data.addClass("test1");
+    data.addClass("test2");
+    data.addRelationship("test", "test1", 1);
+    // Cannot be the destination of multiple compositions
+    ASSERT_ANY_THROW(data.addRelationship("test2", "test1", 1));
+} 
+
+TEST(UMLDataRelationshipTest, DeletingRelationshipWorks)
+{
+    bool haveRelationship = false;
+    UMLData data;
+    data.addClass("test");
+    data.addClass("test1");
+    // Relationship type doesn't matter for this test
+    data.addRelationship("test", "test1", 0);
+    data.deleteRelationship("test", "test1");
+    
+    vector<UMLRelationship> rel = data.getRelationships();
+    // Loop through vector to find proper relationship
+    for(auto i = rel.begin(); i != rel.end(); ++i){
+        // Check and see if the valid relationship still exists
+        if(i->getSource().getName() == "test" && 
+        i->getDestination().getName() == "test1" && 
+        i->getType() == aggregation){
+            haveRelationship = true;
+        }
+    }
+
+    // Relationship should be deleted
+    ASSERT_EQ(haveRelationship, false);
+
+    // Vector should now be empty
+    ASSERT_EQ(rel.size(), std::size_t(0));
+}
+
+TEST(UMLDataRelationshipTest, DeletingNonexistentRelationship)
+{
+    UMLData data;
+
+    // Attempt to delete relationship that does not exist
+    ASSERT_ANY_THROW(data.deleteRelationship("test", "test"));
+    
+    // Same as above, but with the class existing and two different classes
+    data.addClass("test");
+    data.addClass("test1");
+    ASSERT_ANY_THROW(data.deleteRelationship("test", "test"));
+    ASSERT_ANY_THROW(data.deleteRelationship("test", "test1"));
+}
+
+TEST(UMLDataRelationshipTest, GetRelationshipTypeWorks)
+{
+    bool foundRelationship = false;
+    UMLData data;
+    data.addClass("test");
+    data.addClass("test1");
+    // Check for aggregation
+    data.addRelationship("test", "test1", 0);
+    ASSERT_EQ(data.getRelationshipType("test", "test1"), "aggregation");
+    data.deleteRelationship("test", "test1");
+    // Check for composition
+    data.addRelationship("test", "test1", 1);
+    ASSERT_EQ(data.getRelationshipType("test", "test1"), "composition");
+    data.deleteRelationship("test", "test1");
+    // Check for generalization
+    data.addRelationship("test", "test1", 2);
+    ASSERT_EQ(data.getRelationshipType("test", "test1"), "generalization");
+    data.deleteRelationship("test", "test1");
+    // Check for realization
+    data.addRelationship("test", "test1", 3);
+    ASSERT_EQ(data.getRelationshipType("test", "test1"), "realization");
+}
+
+TEST(UMLDataRelationshipTest, GetRelationshipByClassWorks)
+{
+    UMLData data;
+
+    data.addClass("test");
+    data.addClass("test1");
+    data.addClass("test2");
+    data.addRelationship("test", "test1", 0);
+    data.addRelationship("test", "test2", 0);
+    
+    // Vector obtained and relationship vector should be equivalent
+    vector<UMLRelationship> vector1 = data.getRelationshipsByClass("test");
+    vector<UMLRelationship> vector2 = data.getRelationships();
+
+    // Check for identical vector size
+    ASSERT_EQ(vector1.size(), vector2.size());
+    // Check for identical vector contents
+    for (size_t i = 0; i < vector1.size(); ++i) {
+        ASSERT_EQ(vector1[i].getSource().getName(), vector2[i].getSource().getName());
+        ASSERT_EQ(vector1[i].getDestination().getName(), vector2[i].getDestination().getName());
+        ASSERT_EQ(vector1[i].getType(), vector2[i].getType());
+    }
+} 
 
 /*
 TEST(UMLDataAttributeTest, RemovingAttributeWorks) {
@@ -158,14 +287,6 @@ TEST(UMLDataAttributeTest, RemovingAttributeWorks) {
 
 //adds class attribute to specified className
 //void addClassAttribute(string className, UMLAttribute attribute);
-
-/*
-TEST(SquareRootTest, PositiveNos) { 
-    EXPECT_EQ (18.0, square‑root (324.0));
-    EXPECT_EQ (25.4, square‑root (645.16));
-    EXPECT_EQ (50.3321, square‑root (2533.310224));
-}
-*/
 
 /*
 TEST(UMLDataAttributeTest, RemovingAttributeWorks) 
@@ -201,15 +322,7 @@ TEST(UMLRelationshipTest, ConstructorTest)
 {
     UMLClass class1("class1");
     UMLClass class2("class2");
-    ASSERT_ANY_THROW(UMLRelationship relate(class1, class2, 0));
-}
-
-// Test to check if a throw occurs when an invalid integer is sent
-TEST(UMLRelationshipTest, IncorrectTypeTest) 
-{
-    UMLClass class1("class1");
-    UMLClass class2("class2");
-    EXPECT_ANY_THROW(UMLRelationship relate(class1, class2, 4));
+    ASSERT_NO_THROW(UMLRelationship relate(class1, class2, 0));
 }
 
 // Test to check if getting a source works at all

--- a/Tests.cpp
+++ b/Tests.cpp
@@ -264,7 +264,43 @@ TEST(UMLDataRelationshipTest, GetRelationshipByClassWorks)
         ASSERT_EQ(vector1[i].getDestination().getName(), vector2[i].getDestination().getName());
         ASSERT_EQ(vector1[i].getType(), vector2[i].getType());
     }
-} 
+}
+
+TEST(UMLDataRelationshipTest, ChangeRelationshipTypeWorks)
+{
+    UMLData data;
+
+    data.addClass("test");
+    data.addClass("test1");
+
+    // Test to see if relationship was changed
+    data.addRelationship("test", "test1", 0);
+    data.changeRelationshipType("test", "test1", 1);
+    ASSERT_EQ(data.getRelationship("test", "test1").getType(), composition);
+}
+
+TEST(UMLDataRelationshipTest, ChangeRelationshipTypeErrors)
+{
+    UMLData data;
+
+    data.addClass("test");
+    data.addClass("test1");
+    data.addClass("test2");
+
+    data.addRelationship("test", "test1", 0);
+    // Test for bounds
+    ASSERT_ANY_THROW(data.changeRelationshipType("test", "test1", 4));
+    ASSERT_ANY_THROW(data.changeRelationshipType("test", "test1", -1));
+    // Test for identical type
+    ASSERT_ANY_THROW(data.changeRelationshipType("test", "test1", 0));
+    // Test for self-inheritance
+    data.addRelationship("test", "test", 0);
+    ASSERT_ANY_THROW(data.changeRelationshipType("test", "test", 2));
+    ASSERT_ANY_THROW(data.changeRelationshipType("test", "test", 3));
+    // Test for multiple compositions
+    data.addRelationship("test2", "test1", 1);
+    ASSERT_ANY_THROW(data.changeRelationshipType("test", "test1", 1));
+}
 
 /*
 TEST(UMLDataAttributeTest, RemovingAttributeWorks) {

--- a/Tests.cpp
+++ b/Tests.cpp
@@ -1,3 +1,9 @@
+/*
+  Filename   : Tests.cpp
+  Description: UML++ unit tests using the GoogleTest framework.
+  When compiled, performs all tests and displays any errors that occur.
+*/
+
 #include <gtest/gtest.h>
 
 #include "include/UMLData.hpp"
@@ -9,29 +15,42 @@
 
 #include <string>
 #include <iostream>
-// TEST(TestSuiteName, TestName) {
+
+// Test Format
+// **************************
+// TEST(TestSuiteName, TestName) 
+// {
 //   ... test body ...
 // }
+// **************************
 
-//Tests for UMLData.hpp
-TEST(UMLDataAddClassTest, AddClassAndGetCopy) {
+// ****************************************************
+
+// Tests for UMLData.hpp
+// **************************
+
+TEST(UMLDataAddClassTest, AddClassAndGetCopy) 
+{
     UMLData data;
     data.addClass("test");
     ASSERT_EQ("test", data.getClassCopy("test").getName());
 }
 
-TEST(UMLDataAddClassTest, AddClassThatAlreadyExists) {
+TEST(UMLDataAddClassTest, AddClassThatAlreadyExists) 
+{
     UMLData data;
     data.addClass("test");
     ASSERT_ANY_THROW(data.addClass("test"));
 }
 
-TEST(UMLDataRemoveClassTest, RemoveClassThatDoesntExist) {
+TEST(UMLDataRemoveClassTest, RemoveClassThatDoesntExist) 
+{
     UMLData data;
     ASSERT_ANY_THROW(data.deleteClass("test"));
 }
 
-TEST(UMLDataRenameClassTest, RenameAClassWorks) {
+TEST(UMLDataRenameClassTest, RenameAClassWorks) 
+{
     UMLData data;
     string oldName;
     string updatedName;
@@ -42,13 +61,15 @@ TEST(UMLDataRenameClassTest, RenameAClassWorks) {
     ASSERT_EQ(updatedName, updatedName);
 }
 
-TEST(UMLDataRenameClassTest, RenameClassIntoClassThatAlreadyExists) {
+TEST(UMLDataRenameClassTest, RenameClassIntoClassThatAlreadyExists) 
+{
     UMLData data;
     data.addClass("test");
     ASSERT_ANY_THROW(data.changeClassName("test", "test"));
 }
 
-TEST(UMLDataAttributeTest, AddAttributeWorks) {
+TEST(UMLDataAttributeTest, AddAttributeWorks) 
+{
     UMLData data;
     data.addClass("test");
     UMLAttribute attribute("hastest");
@@ -60,12 +81,12 @@ TEST(UMLDataAttributeTest, AddAttributeWorks) {
        }
 }
 
-TEST(UMLDataAttributeTest, ChangeAttributeNameWorks) {
-   
+TEST(UMLDataAttributeTest, ChangeAttributeNameWorks) 
+{
     bool hasTestGone;
-    hasTestGone == true;
+    hasTestGone = true;
     bool newHasTestPresent;
-    newHasTestPresent == false;
+    newHasTestPresent = false;
 
     UMLData data;
     data.addClass("test");
@@ -75,17 +96,17 @@ TEST(UMLDataAttributeTest, ChangeAttributeNameWorks) {
 
         for (UMLAttribute attr : data.getClassAttributes("test")) {
            if(attr.getAttributeName() == "hastest"){
-               hasTestGone == false;
+               hasTestGone = false;
            }
             if(attr.getAttributeName() == "newHasTest"){
-              newHasTestPresent == true;
+              newHasTestPresent = true;
            }
        }
       ASSERT_EQ(hasTestGone, newHasTestPresent);  
 }
 
-
-TEST(UMLDataAttributeTest, RemovingNonExistantAttribute) {
+TEST(UMLDataAttributeTest, RemovingNonExistantAttribute) 
+{
     UMLData data;
     data.addClass("test");
     UMLAttribute attribute("hastestt");
@@ -93,8 +114,8 @@ TEST(UMLDataAttributeTest, RemovingNonExistantAttribute) {
 }
 
 /*
-TEST(UMLDataRelationshipTest, AddingRelationshipWorks) {
-   
+TEST(UMLDataRelationshipTest, AddingRelationshipWorks) 
+{
     bool haveRelationship;
     haveRelationship == false;
     UMLData data;
@@ -102,27 +123,19 @@ TEST(UMLDataRelationshipTest, AddingRelationshipWorks) {
     data.addClass("test1");
     vector<UMLRelationship> rel = data.getRelationships();
     
-
-
     data.addRelationship("test", "test1");
    
-
-
-
-   for(auto i = rel.begin(); i != rel.end(); ++i){
-
-           if(&(rel[i].getSource()) == "test1"){
-          
-             haveRelationship == true;
-           }
-           else if(&(rel[i].getDestination()) == "test1"){
-               haveRelationship == true;
-           }
+    for(auto i = rel.begin(); i != rel.end(); ++i){
+        if(&(rel[i].getSource()) == "test1"){
+            haveRelationship == true;
+        }
+        else if(&(rel[i].getDestination()) == "test1"){
+            haveRelationship == true;
+        }
    }
-  
-
-
     ASSERT_EQ(haveRelationship, true); 
+}
+*/
 
 /*
 TEST(UMLDataAttributeTest, RemovingAttributeWorks) {
@@ -132,21 +145,19 @@ TEST(UMLDataAttributeTest, RemovingAttributeWorks) {
     data.addClassAttribute("test", attribute);
     data.removeClassAttribute("test", attribute);
     ASSERT_EQ(data.getClassCopy("test").removeClassAttribute("test", attribute), "");
-
 }
 */
 
 //Attribute tests
 /*
 -Removing an attribute works
--removing an attribute  that doestn exist should throw an error
-- renaming an attribute should work
-- renaming an attribute to another attribute that already exists should throw an error
+-Removing an attribute  that doestn exist should throw an error
+-Renaming an attribute should work
+-Renaming an attribute to another attribute that already exists should throw an error
 */
 
-
- //adds class attribute to specified className
-     //   void addClassAttribute(string className, UMLAttribute attribute);
+//adds class attribute to specified className
+//void addClassAttribute(string className, UMLAttribute attribute);
 
 /*
 TEST(SquareRootTest, PositiveNos) { 
@@ -156,9 +167,9 @@ TEST(SquareRootTest, PositiveNos) {
 }
 */
 
-
 /*
-TEST(UMLDataAttributeTest, RemovingAttributeWorks) {
+TEST(UMLDataAttributeTest, RemovingAttributeWorks) 
+{
       
     bool hasTestGone;
     hasTestGone == true;
@@ -178,62 +189,130 @@ TEST(UMLDataAttributeTest, RemovingAttributeWorks) {
            }
        }
     ASSERT_EQ(hasTestGone, true); 
- */
-    
+*/
 
+// ****************************************************
 
+// Tests for UMLRelationship.hpp
+// **************************
 
-
-
-//Tests for UMLRelationship.hpp
-
-TEST(UMLRelationshipTest, GetSourceTest) {
+// Test to check if constructing a generic relationship works at all
+TEST(UMLRelationshipTest, ConstructorTest) 
+{
     UMLClass class1("class1");
     UMLClass class2("class2");
-    UMLRelationship relate(class1, class2);
+    ASSERT_ANY_THROW(UMLRelationship relate(class1, class2, 0));
+}
+
+// Test to check if a throw occurs when an invalid integer is sent
+TEST(UMLRelationshipTest, IncorrectTypeTest) 
+{
+    UMLClass class1("class1");
+    UMLClass class2("class2");
+    EXPECT_ANY_THROW(UMLRelationship relate(class1, class2, 4));
+}
+
+// Test to check if getting a source works at all
+TEST(UMLRelationshipTest, GetSourceTest) 
+{
+    UMLClass class1("class1");
+    UMLClass class2("class2");
+    // Relationship type doesn't matter for this test
+    UMLRelationship relate(class1, class2, 0);
     ASSERT_EQ(&relate.getSource(), &class1);
 }
 
-TEST(UMLRelationshipTest, GetDestinationTest) {
+// Test to check if getting a destination works at all
+TEST(UMLRelationshipTest, GetDestinationTest) 
+{
     UMLClass class1("class1");
     UMLClass class2("class2");
-    UMLRelationship relate(class1, class2);
+    // Relationship type doesn't matter for this test
+    UMLRelationship relate(class1, class2, 0);
     ASSERT_EQ(&relate.getDestination(), &class2);
 }
 
-TEST(UMLRelationshipTest, GetDestinationTest2) {
+// Test to see if the destination was simultaneously set as the source
+TEST(UMLRelationshipTest, GetDestinationTest2) 
+{
     UMLClass class1("class1");
     UMLClass class2("class2");
-    UMLRelationship relate(class1, class2);
+    // Relationship type doesn't matter for this test
+    UMLRelationship relate(class1, class2, 0);
     bool test = &relate.getDestination() == &class1;
     ASSERT_EQ(test, false);
-
 }
-//Tests for UMLAttribute.hpp
-TEST(UMLAttributeTest, GetAttributeNameTest) {
+
+// Test to check if getting a type works at all
+TEST(UMLRelationshipTest, GetTypeTest) {
+    UMLClass class1("class1");
+    UMLClass class2("class2");
+    UMLRelationship relate(class1, class2, 0);
+    ASSERT_EQ(relate.getType() == aggregation, true);
+}
+
+// Test to check if setting a type works at all
+TEST(UMLRelationshipTest, SetTypeTest) {
+    UMLClass class1("class1");
+    UMLClass class2("class2");
+    UMLRelationship relate(class1, class2, 0);
+    relate.setType(composition);
+    ASSERT_EQ(relate.getType() == composition, true);
+}
+
+// Make and set relationships of each type and see if they hold the correct type
+TEST(UMLRelationshipTest, GetAllTypeTest) 
+{
+    UMLClass class1("class1");
+    UMLClass class2("class2");
+    UMLRelationship relate(class1, class2, 0);
+    ASSERT_EQ(relate.getType() == aggregation, true);
+    relate.setType(composition);
+    ASSERT_EQ(relate.getType() == composition, true);
+    relate.setType(generalization);
+    ASSERT_EQ(relate.getType() == generalization, true);
+    relate.setType(realization);
+    ASSERT_EQ(relate.getType() == realization, true);
+}
+
+// ****************************************************
+
+// Tests for UMLAttribute.hpp
+// **************************
+
+TEST(UMLAttributeTest, GetAttributeNameTest) 
+{
     UMLAttribute attribute("test");
     ASSERT_EQ(attribute.getAttributeName(), "test");
 }
 
-TEST(UMLAttributeTest, RenameAttributeNameTest) {
+TEST(UMLAttributeTest, RenameAttributeNameTest) 
+{
     UMLAttribute attribute("test");
     attribute.changeName("test2");
     ASSERT_EQ(attribute.getAttributeName(), "test2");
 }
 
-//Tests for UMLClass.hpp
-TEST(UMLClassFileTest, GetNameWorks) {
+// ****************************************************
+
+// Tests for UMLClass.hpp
+// **************************
+
+TEST(UMLClassFileTest, GetNameWorks) 
+{
     UMLClass class1("test");
     ASSERT_EQ(class1.getName(), "test");
 }
 
-TEST(UMLClassFileTest, ChangeNameWorks) {
+TEST(UMLClassFileTest, ChangeNameWorks) 
+{
     UMLClass class1("test");
     class1.changeName("newTest");
     ASSERT_EQ(class1.getName(), "newTest");
 }
 
-TEST(UMLClassFileTest, AddAttributeWorks) {
+TEST(UMLClassFileTest, AddAttributeWorks) 
+{
     UMLClass class1("test");
     UMLAttribute attribute("testattribute");
     class1.addAttribute(attribute);
@@ -250,7 +329,8 @@ TEST(UMLClassFileTest, AddAttributeWorks) {
     ASSERT_EQ(attrFound, true);
 }
 
-TEST(UMLClassFileTest, ChangeAttributeWorks) {
+TEST(UMLClassFileTest, ChangeAttributeWorks) 
+{
     UMLClass class1("test");
     UMLAttribute attribute("testattributeOld");
     class1.addAttribute(attribute);
@@ -278,7 +358,8 @@ TEST(UMLClassFileTest, ChangeAttributeWorks) {
     ASSERT_EQ(attrFound, true);
 }
 
-TEST(UMLClassFileTest, DeleteAttributeWorks) {
+TEST(UMLClassFileTest, DeleteAttributeWorks) 
+{
     UMLClass class1("test");
     UMLAttribute attribute("testattribute");
     class1.addAttribute(attribute);
@@ -296,7 +377,8 @@ TEST(UMLClassFileTest, DeleteAttributeWorks) {
     ASSERT_EQ(attrFound, false);
 }
 
-TEST(UMLClassFileTest, FindAttributeWorks) {
+TEST(UMLClassFileTest, FindAttributeWorks) 
+{
     UMLClass class1("test");
     UMLAttribute attribute("testattribute");
     class1.addAttribute(attribute);
@@ -305,7 +387,8 @@ TEST(UMLClassFileTest, FindAttributeWorks) {
     ASSERT_EQ(class1.findAttribute("testattribute")->getAttributeName(), attribute.getAttributeName());
 }
 
-TEST(UMLClassFileTest, GetAttributesWorks) {
+TEST(UMLClassFileTest, GetAttributesWorks) 
+{
     UMLClass class1("test");
     UMLAttribute attribute("testattribute");
     class1.addAttribute(attribute);
@@ -326,26 +409,32 @@ TEST(UMLClassFileTest, GetAttributesWorks) {
     ASSERT_EQ(isEqual, true);
 }
 
+// ****************************************************
 
-//Tests for UMLParameter.hpp
-//**************************
+// Tests for UMLParameter.hpp
+// **************************
 
-//Tests creation of a Parameter and getting it's name and type works
-TEST(UMLParameterTest, GetParameterNameTest) {
+// Tests creation of a Parameter and getting it's name and type works
+TEST(UMLParameterTest, GetParameterNameTest) 
+{
     UMLParameter parameter("name","type");
     ASSERT_EQ(parameter.getName(), "name");
     ASSERT_EQ(parameter.getType(), "type");
 }
 
-//Tests renaming Parameter works
-TEST(UMLParameterTest, RenameParameterNameTest) {
+// Tests renaming Parameter works
+TEST(UMLParameterTest, RenameParameterNameTest) 
+{
     UMLParameter parameter("name","type");
     parameter.changeName("name2");
     ASSERT_EQ(parameter.getName(), "name2");
 }
-//Tests changing Parameter type works
-TEST(UMLParameterTest, ChangeParameterTypeTest) {
+// Tests changing Parameter type works
+TEST(UMLParameterTest, ChangeParameterTypeTest) 
+{
     UMLParameter parameter("name","type");
     parameter.changeType("type2");
     ASSERT_EQ(parameter.getType(), "type2");
 }
+
+// ****************************************************

--- a/UMLData.cpp
+++ b/UMLData.cpp
@@ -1,11 +1,12 @@
 /*
-  Filename   : UMLFile.cpp
-  Description: Implementation of a file.
+  Filename   : UMLData.cpp
+  Description: Implementation of the data storage model.
 */
 
 //--------------------------------------------------------------------
 // System includes
 #include "include/UMLFile.hpp"
+#include "include/UMLRelationship.hpp"
 //--------------------------------------------------------------------
 
 // Empty constructor
@@ -64,10 +65,10 @@ void UMLData::addClass(string name, vector<UMLAttribute> attributes)
     addClass(UMLClass(name, attributes));
 }
 
-// Takes in src string and dest string, creates relationship and adds to relationships vector
-void UMLData::addRelationship(string srcName, string destName)
+// Takes in src string, dest string, and type int creates relationship and adds to relationships vector
+void UMLData::addRelationship(string srcName, string destName, int type)
 {
-    addRelationship(getClass(srcName), getClass(destName));
+    addRelationship(UMLRelationship(getClass(srcName), getClass(destName), type-1));
 }
 
 // Takes in className string and returns a vector of all the relationshps associated with that class
@@ -250,15 +251,23 @@ UMLRelationship& UMLData::getRelationship(string srcName, string destName)
 // Takes in relationship object and adds it to relationship vector
 void UMLData::addRelationship(const UMLRelationship& relIn)
 {
+    // Check to see if relationship already exists
     int loc = findRelationship(relIn.getSource(), relIn.getDestination());
     if (loc >= 0)
         throw "New relationship already exists";
-
+    // Generalization/realization check for self relationships
+    else if (relIn.getType() == generalization || relIn.getType() == realization) {
+        if (relIn.getSource().getName() == relIn.getDestination().getName()) {
+            throw "Cannot have self-relationship of generalizations or realizations";
+        }
+    }
+    // Composition check for duplicate destinations
+    else if (relIn.getType() == composition) {
+        for(UMLRelationship relationship : getRelationships()) {
+            if (relationship.getDestination().getName() == relIn.getDestination().getName()) {
+                throw "Class can not be the destination for more than one composition";
+            }
+        }
+    }
     relationships.push_back(relIn); 
-}
-
-// Creates relationship from two classes and adds to relationshp vector
-void UMLData::addRelationship(const UMLClass& sourceClass, const UMLClass& destClass)
-{
-    addRelationship(UMLRelationship(sourceClass, destClass));
 }

--- a/UMLData.cpp
+++ b/UMLData.cpp
@@ -68,16 +68,16 @@ void UMLData::addClass(string name, vector<UMLAttribute> attributes)
 // Takes in src string, dest string, and type int creates relationship and adds to relationships vector
 void UMLData::addRelationship(string srcName, string destName, int type)
 {
+    if(type < 0 || type > 3) 
+        throw "Invalid type";
     addRelationship(UMLRelationship(getClass(srcName), getClass(destName), type));
 }
 
-// Takes in className string and returns a vector of all the relationshps associated with that class
+// Takes in className string and returns a vector of all the relationships associated with that class
 vector<UMLRelationship> UMLData::getRelationshipsByClass(string classNameIn)
 {
     vector<UMLRelationship> relationshipsContainingClass;
-
     string className = getClass(classNameIn).getName();
-
     for (int i = 0; i < relationships.size(); ++i)
     {
         //pull src and destination classes from vector location
@@ -90,7 +90,6 @@ vector<UMLRelationship> UMLData::getRelationshipsByClass(string classNameIn)
         }
     }
     return relationshipsContainingClass;
-
 }
 
 // Deletes relationshp based on two strings

--- a/UMLData.cpp
+++ b/UMLData.cpp
@@ -68,7 +68,7 @@ void UMLData::addClass(string name, vector<UMLAttribute> attributes)
 // Takes in src string, dest string, and type int creates relationship and adds to relationships vector
 void UMLData::addRelationship(string srcName, string destName, int type)
 {
-    addRelationship(UMLRelationship(getClass(srcName), getClass(destName), type-1));
+    addRelationship(UMLRelationship(getClass(srcName), getClass(destName), type));
 }
 
 // Takes in className string and returns a vector of all the relationshps associated with that class

--- a/UMLData.cpp
+++ b/UMLData.cpp
@@ -102,6 +102,24 @@ void UMLData::deleteRelationship(string srcName, string destName)
     relationships.erase(relationships.begin() + loc);
 }
 
+// Returns string representation of relationship type
+string UMLData::getRelationshipType(const string& srcName, const string& destName) {
+    Type type = getRelationship(srcName, destName).getType();
+    switch (type) {
+        case aggregation :
+            return "aggregation";
+        case composition :
+            return "composition";
+        case generalization :
+            return "generalization";
+        case realization :
+            return "realization";
+        default :
+            return "none";
+    }
+    return "none";
+}
+
 // Deletes a class by string in the classes vector
 void UMLData::deleteClass(string name)
 {

--- a/UMLFile.cpp
+++ b/UMLFile.cpp
@@ -89,7 +89,7 @@ void UMLFile::getUMLRelationshipVec(UMLData& data)
         string dest = rel["dest"];
         string src = rel["src"];
 
-        data.addRelationship(dest, src);
-
+        // Temp value for type
+        data.addRelationship(dest, src, 1);
     }
 }

--- a/UMLRelationship.cpp
+++ b/UMLRelationship.cpp
@@ -9,10 +9,10 @@
 //--------------------------------------------------------------------
 
 // Constructor for class objects
-UMLRelationship::UMLRelationship(const UMLClass& src, const UMLClass& dest, Type type)
+UMLRelationship::UMLRelationship(const UMLClass& src, const UMLClass& dest, int type)
 :source(&src)
 ,destination(&dest)
-,relationshipType(type)
+,relationshipType((Type) type)
 {
 }
 

--- a/UMLRelationship.cpp
+++ b/UMLRelationship.cpp
@@ -35,6 +35,20 @@ Type UMLRelationship::getType() const
 }
 
 // Set type of relationship
-void UMLRelationship::setType(Type newType) {
-  relationshipType = newType;
+void UMLRelationship::setType(int newType) {
+  if (newType == 0) {
+    relationshipType = aggregation;
+  }
+  else if (newType == 1) {
+    relationshipType = composition;
+  }
+  else if (newType == 2) {
+    relationshipType = generalization;
+  }
+  else if (newType == 3) {
+    relationshipType = realization;
+  }
+  else {
+    throw "Invalid type";
+  }
 }

--- a/UMLRelationship.cpp
+++ b/UMLRelationship.cpp
@@ -9,9 +9,10 @@
 //--------------------------------------------------------------------
 
 // Constructor for class objects
-UMLRelationship::UMLRelationship(const UMLClass& src, const UMLClass& dest)
+UMLRelationship::UMLRelationship(const UMLClass& src, const UMLClass& dest, Type type)
 :source(&src)
 ,destination(&dest)
+,relationshipType(type)
 {
 }
 
@@ -25,4 +26,15 @@ const UMLClass& UMLRelationship::getSource() const
 const UMLClass& UMLRelationship::getDestination() const
 {
 	return *destination;
+}
+
+// Grab type of relationship
+Type UMLRelationship::getType() const
+{
+  return relationshipType;
+}
+
+// Set type of relationship
+void UMLRelationship::setType(Type newType) {
+  relationshipType = newType;
 }

--- a/help.txt
+++ b/help.txt
@@ -29,12 +29,16 @@ UML++ has the following hierarchy for its command-line interface:
     - [4] Back: Returns back to the main set of commands.
     
 - [3] Relationship: Lists operations for modifying relationships.
-    - [1] Add: Prompts for a source class and a destination class. If both 
-               classes exist and the relationship doesn't already exist, a new
-               relationship is made.
+    - [1] Add: Prompts for a source class and a destination class, alongside a
+               type. If there is not already a relationship with this source
+               destination combination and no relationship type rules are being
+               broken, a new relationship will be made.
     - [2] Remove: Prompts for a source class and a destination class. If the 
-                  relationship exists, it will be removed.
-    - [3] Back: Returns back to the main set of commands.
+                relationship exists, it will be removed.
+    - [3] Modify Type: Prompts for a source class and a destination class,
+                       alongside a new type. Changes the relationship to have 
+                       the new type, given that this does not cause any errors.
+    - [4] Back: Returns back to the main set of commands.
     
 - [4] List: Lists operations for viewing information within the diagram.
     - [1] Class: Prompts for a class name. If the class exists, information 

--- a/include/UMLData.hpp
+++ b/include/UMLData.hpp
@@ -55,7 +55,7 @@ class UMLData
         // Takes in src string, dest string, and type int creates relationship and adds to relationships vector
         void addRelationship(string srcName, string destName, int type);
         
-        // Takes in className string and returns a vector of all the relationshps associated with that class
+        // Takes in className string and returns a vector of all the relationships associated with that class
         vector<UMLRelationship> getRelationshipsByClass(string className);
 
         // Deletes relationshp based on two strings

--- a/include/UMLData.hpp
+++ b/include/UMLData.hpp
@@ -64,6 +64,12 @@ class UMLData
         // Returns string representation of relationship type
         string getRelationshipType(const string& srcName, const string& destName);
 
+        // Modifies relationship type given a new relationship type 
+        void changeRelationshipType(const string& srcName, const string& destName, int newType);
+
+        // Gets relationship reference for the given string class names
+        UMLRelationship& getRelationship(string srcName, string destName);
+
         // Deletes a class by string in the classes vector
         void deleteClass(string name);
 
@@ -97,9 +103,6 @@ class UMLData
 
         // Gets class reference for the given name
         UMLClass& getClass(string name);
-
-        // Gets relationship reference for the given string class names
-        UMLRelationship& getRelationship(string srcName, string destName);
 
         // Takes in relationship object and adds it to relationship vector
         void addRelationship(const UMLRelationship& relationshipIn);

--- a/include/UMLData.hpp
+++ b/include/UMLData.hpp
@@ -1,7 +1,8 @@
 #pragma once
 /*
   Filename   : UMLData.hpp
-  Description: Stores the Relationship and Class information of the current state 
+  Description: Stores the relationship and class information, serving as
+  the primary model for the UML class diagram.
 */
 
 //--------------------------------------------------------------------
@@ -51,8 +52,8 @@ class UMLData
         // Takes in name and vector of attributes and creates class and adds to vector of classes
         void addClass(string name, vector<UMLAttribute> attributes);
 
-        // Takes in src string and dest string, creates relationship and adds to relationships vector
-        void addRelationship(string srcName, string destName);
+        // Takes in src string, dest string, and type int creates relationship and adds to relationships vector
+        void addRelationship(string srcName, string destName, int type);
         
         // Takes in className string and returns a vector of all the relationshps associated with that class
         vector<UMLRelationship> getRelationshipsByClass(string className);
@@ -99,7 +100,4 @@ class UMLData
 
         // Takes in relationship object and adds it to relationship vector
         void addRelationship(const UMLRelationship& relationshipIn);
-
-        // Creates relationship from two classes and adds to relationshp vector
-        void addRelationship(const UMLClass& sourceClass, const UMLClass& destClass);
 };

--- a/include/UMLData.hpp
+++ b/include/UMLData.hpp
@@ -61,6 +61,9 @@ class UMLData
         // Deletes relationshp based on two strings
         void deleteRelationship(string srcName, string destName);
 
+        // Returns string representation of relationship type
+        string getRelationshipType(const string& srcName, const string& destName);
+
         // Deletes a class by string in the classes vector
         void deleteClass(string name);
 

--- a/include/UMLRelationship.hpp
+++ b/include/UMLRelationship.hpp
@@ -2,8 +2,7 @@
 /*
   Filename   : UMLRelationship.hpp
   Description: Serves as an object for which information about a relationship
-  in the UML diagram is stored. To be further expanded with different types
-  of relationships.
+  in the UML diagram is stored, alongside its relationship type.
 */
 
 //--------------------------------------------------------------------
@@ -12,20 +11,37 @@
 #include "UMLClass.hpp"
 //--------------------------------------------------------------------
 
+//--------------------------------------------------------------------
+/* Types of relationships 
+Aggregation: shared, ownerless collection 
+Composition: unshared, 'has-a' relationship collection
+Generalization: inheritance relationship
+Realization: interface implementation relationship */
+//--------------------------------------------------------------------
+enum Type {aggregation, composition, generalization, realization};
+
 class UMLRelationship
 {
 	private:
 		// Name of class that owns attribute and name of attribute
 		const UMLClass* source;
 		const UMLClass* destination;
+		// Type of relationship
+		Type relationshipType;
 
 	public:
 		// Constructor for class objects
-		UMLRelationship(const UMLClass& src, const UMLClass& dest);
+		UMLRelationship(const UMLClass& src, const UMLClass& dest, Type type);
 
 		// Grab name of the source class
 		const UMLClass& getSource() const;
 
-		// Grab name of the destination classs
+		// Grab name of the destination class
 		const UMLClass& getDestination() const;
+
+		// Grab type of relationship
+		Type getType() const;
+
+		// Set type of relationship
+		void setType(Type newType);
 };

--- a/include/UMLRelationship.hpp
+++ b/include/UMLRelationship.hpp
@@ -31,7 +31,7 @@ class UMLRelationship
 
 	public:
 		// Constructor for class objects
-		UMLRelationship(const UMLClass& src, const UMLClass& dest, Type type);
+		UMLRelationship(const UMLClass& src, const UMLClass& dest, int type);
 
 		// Grab name of the source class
 		const UMLClass& getSource() const;

--- a/include/UMLRelationship.hpp
+++ b/include/UMLRelationship.hpp
@@ -13,10 +13,10 @@
 
 //--------------------------------------------------------------------
 /* Types of relationships 
-Aggregation: shared, ownerless collection 
-Composition: unshared, 'has-a' relationship collection
-Generalization: inheritance relationship
-Realization: interface implementation relationship */
+[0] Aggregation: shared, ownerless collection 
+[1] Composition: unshared, 'has-a' relationship collection
+[2] Generalization: inheritance relationship
+[3] Realization: interface implementation relationship */
 //--------------------------------------------------------------------
 enum Type {aggregation, composition, generalization, realization};
 
@@ -43,5 +43,5 @@ class UMLRelationship
 		Type getType() const;
 
 		// Set type of relationship
-		void setType(Type newType);
+		void setType(int newType);
 };


### PR DESCRIPTION
Adds support for relationship types, which are as follows, along with their enum values:
[0] Aggregation: shared, ownerless collection 
[1] Composition: unshared, 'has-a' relationship collection
[2] Generalization: inheritance relationship
[3] Realization: interface implementation relationship
UMLRelationship, UMLData, and CLI were modified to support this new change, including error checking and tests within Tests.cpp. This also contains minor formatting changes for Tests.cpp for the sake of readability.

This branch does NOT implement the modifications necessary to save and load the types of relationships. All relationships will currently be saved as aggregations, and proper support should be implemented in its own branch. Tests were made for relationship types for all EXCEPT the CLI. When reviewing, please build your own copy of the branch and manually test to see if the CLI works as intended. Proper support for tests for the CLI in general need to be figured out within their own branch.
