### PR TITLE
UMLClass checkAttribute Fix

### DIFF
--- a/UMLClass.cpp
+++ b/UMLClass.cpp
@@ -135,7 +135,7 @@ bool UMLClass::checkAttribute(std::shared_ptr<UMLAttribute> attribute)
 			if (classAttributes[i]->getAttributeName() == attribute->getAttributeName() && classAttributes[i]->identifier() == "field") {
 				return true;
 			}
-			// If they share the same name but the other one is a field, check parameters
+			// If they share the same name but they are both methods, check parameters
 			else if (classAttributes[i]->getAttributeName() == attribute->getAttributeName() && classAttributes[i]->identifier() == "method"){
 				list<UMLParameter> params1 = std::dynamic_pointer_cast<UMLMethod>(classAttributes[i])->getParam();
 				list<UMLParameter> params2 = std::dynamic_pointer_cast<UMLMethod>(attribute)->getParam();


### PR DESCRIPTION
Now properly checks based on type signature, only passing if each parameter has the exact same set of types in the same order. This does not fix any other signature errors within other files, only within UMLClass.cpp.