### PR TITLE
Deleted MOST of the UMLData overloads. The rest are still in use.

### DIFF
--- a/Tests.cpp
+++ b/Tests.cpp
@@ -667,7 +667,7 @@ TEST (UMLFileTest, AddComponentsTest)
 TEST (UMLDataAddClassTest, AddClassAndGetCopy)
 {
   UMLData data;
-  data.addClass (UMLClass ("test"));
+  data.addClassObject (UMLClass ("test"));
   ASSERT_EQ ("test", data.getClassCopy ("test").getName());
 }
 
@@ -675,8 +675,8 @@ TEST (UMLDataAddClassTest, AddClassAndGetCopy)
 TEST (UMLDataAddClassTest, AddClassThatAlreadyExists)
 {
   UMLData data;
-  data.addClass (UMLClass ("test"));
-  ERR_CHECK (data.addClass (UMLClass ("test")), "Class name already exists");
+  data.addClassObject (UMLClass ("test"));
+  ERR_CHECK (data.addClassObject (UMLClass ("test")), "Class name already exists");
 }
 
 // Shouldn't be able to remove a class that doesn't exist
@@ -714,42 +714,10 @@ TEST (UMLDataRenameClassTest, RenameClassIntoClassThatAlreadyExists)
 // Tests for UMLData involving attributes (method/field)
 // **************************
 
-// Checks to see if adding method in UMLData works.
-// TODO: Clean up variable names.
-TEST (UMLDataAttributeTest, AddMethodTest)
-{
-  UMLData data;
-  data.addClass ("test");
-  UMLMethod attribute ("hastest", "type", std::list<UMLParameter>{});
-  data.addClassAttribute ("test", attribute);
-  for (auto attr : data.getClassAttributes ("test"))
-  {
-    if (attr->getAttributeName() == "hastest")
-    {
-      ASSERT_EQ (attr->getAttributeName(), "hastest");
-    }
-  }
-}
-
-// Checks to see if adding a field in UMLData works.
-// TODO: Clean up variable names.
-TEST (UMLDataAttributeTest, AddFieldTest)
-{
-  UMLData data;
-  data.addClass ("test");
-  UMLField attribute ("hastest", "type");
-  data.addClassAttribute ("test", attribute);
-  for (auto attr : data.getClassAttributes ("test"))
-  {
-    if (attr->getAttributeName() == "hastest")
-    {
-      ASSERT_EQ (attr->getAttributeName(), "hastest");
-    }
-  }
-}
 
 // Checks to see if changing the name of a field in UMLData works.
 // TODO: Clean up variable names.
+/*
 TEST (UMLDataAttributeTest, ChangeMethodNameTest)
 {
   bool hasTestGone;
@@ -776,9 +744,11 @@ TEST (UMLDataAttributeTest, ChangeMethodNameTest)
   }
   ASSERT_EQ (hasTestGone, newHasTestPresent);
 }
+*/
 
 // Checks to see if changing the name of a field in UMLData works.
 // TODO: Clean up variable names.
+/*
 TEST (UMLDataAttributeTest, ChangeFieldNameTest)
 {
   bool hasTestGone;
@@ -804,7 +774,7 @@ TEST (UMLDataAttributeTest, ChangeFieldNameTest)
     }
   }
   ASSERT_EQ (hasTestGone, newHasTestPresent);
-}
+}*/
 
 // Checks if an error occurs when you attempt to remove a class attribute that isn't owned by the class.
 TEST (UMLDataAttributeTest, RemovingNonExistantAttribute)

--- a/UMLData.cpp
+++ b/UMLData.cpp
@@ -46,7 +46,7 @@ UMLData::UMLData(const vector<UMLClass>& vclass)
 {
   for (UMLClass uclass : vclass)
   {
-    addClass(uclass);
+    addClassObject(uclass);
   }
 }
 
@@ -284,10 +284,10 @@ json UMLData::getJson()
  * 
  * @param classIn 
  */
-void UMLData::addClass(const UMLClass& classIn)
+void UMLData::addClassObject(const UMLClass& classIn)
 {
   //check if already exists
-  if (doesClassExist(classIn))
+  if (doesClassExist(classIn.getName()))
     throw std::runtime_error("Class name already exists");
   if (!isValidName(classIn.getName()))
     throw std::runtime_error("Class name not valid");
@@ -306,23 +306,7 @@ void UMLData::addClass(const UMLClass& classIn)
  */
 void UMLData::addClass(string name)
 {
-  addClass(UMLClass(name));
-}
-
-
-/************************************/
-
-
-/**
- * @brief Takes in name and vector of attributes and creates class 
- * and adds to vector of classes.
- * 
- * @param name 
- * @param attributes 
- */
-void UMLData::addClass(string name, vector<UMLAttribute> attributes)
-{
-  addClass(UMLClass(name, attributes));
+  addClassObject(UMLClass(name));
 }
 
 
@@ -343,25 +327,6 @@ void UMLData::addRelationship(string srcName, string destName, int type)
   if (type < 0 || type > 3) 
     throw std::runtime_error("Invalid type");
   addRelationship(UMLRelationship(getClass(srcName), getClass(destName), type));
-}
-
-
-/************************************/
-
-
-/**
- * @brief Adds class attribute to specified className.
- * 
- * @param className 
- * @param attribute 
- */
-void UMLData::addClassAttribute(string className, UMLAttribute attribute)
-{
-  if (!isValidName(attribute.getAttributeName()))
-    throw std::runtime_error("Attribute name is not valid");
-  else if (!isValidName(attribute.getType()))
-    throw std::runtime_error("Attribute type is not valid");
-  getClass(className).addAttribute(attribute);
 }
 
 
@@ -487,26 +452,6 @@ void UMLData::deleteRelationship(string srcName, string destName)
 }
 
 
-/************************************/
-
-
-/**
- * @brief Removes className class attribute by the name.
- * 
- * @param className 
- * @param attributeName 
- */
-void UMLData::removeClassAttribute(string className, string attributeName)
-{
-  for (attr_ptr attr : getClass(className).getAttributes()) {
-    if (attr->getAttributeName() == attributeName) {
-      getClass(className).deleteAttribute(attributeName);
-      return;
-    }
-  }
-  throw std::runtime_error("Attribute does not exist");
-}
-
 
 /************************************/
 
@@ -566,26 +511,6 @@ void UMLData::changeClassName(string oldName, string newName)
     throw std::runtime_error("New class name is not valid");
   getClass(oldName).changeName(newName);
   //change name in relationship
-}
-
-
-/************************************/
-
-
-/**
- * @brief Changes class attribute by the new attribute name.
- * 
- * @param className 
- * @param oldAttributeName 
- * @param newAttributeName 
- */
-void UMLData::changeAttributeName(string className, string oldAttributeName, string newAttributeName)
-{
-  if (findAttribute(newAttributeName, getClassAttributes(className)) >= 0)
-    throw std::runtime_error("Attribute name already exists");
-  if (!isValidName(newAttributeName))
-    throw std::runtime_error("New attribute name is not valid");
-  getClass(className).changeAttributeName(oldAttributeName, newAttributeName);
 }
 
 
@@ -759,25 +684,6 @@ bool UMLData::doesClassExist(const string& name)
 
 
 /**
- * @brief Checks if class exists with classes list (class argument)
- * 
- * @param uclass 
- * @return true 
- * @return false 
- */
-bool UMLData::doesClassExist(const UMLClass& uclass)
-{
-  list<UMLClass>::iterator findIter = findClass(uclass);
-  if (findIter == classes.end())
-    return false;
-  return true;
-}
-
-
-/************************************/
-
-
-/**
  * @brief Checks to see if relationship exists.
  * 
  * @param source 
@@ -918,63 +824,27 @@ void UMLData::deleteParameter(method_ptr method, string paramName)
   method->deleteParameter(paramName);
 }
 
+
 /************************************/
 
+
 /**
- * @brief Used for comparing overloaded methods to see
- * if they're valid. Takes in 2 method pointers, and 
- * compares their parameters by type. Returns false if 
- * the methods are EXACT duplicates, or if their return 
- * types are different.
+ * @brief THIS WILL BE DELETED!!!!!!!!!!!!!!
  * 
- * Returns false:
- * 
- * void method(int param1, string param2, bool param3)
- * void method(int param1, string param2, bool param3)
- * ---------------------------------------------------
- * void method(int param1)
- * string method()
- * ---------------------------------------------------
- * void method(int param1, string param2, bool param3)
- * void method(int paramOne, string bloop, bool thingy)
- * 
- * Returns true:
- * 
- * void method(int param1, bool param2, string param3)
- * void method(string param1, int param2, bool param3)
- * ---------------------------------------------------
- * void method(int param1, string param2, bool param3)
- * void method(int param1, string param2)
- * 
- * @param method1 
- * @param method2 
- * @return true 
- * @return false 
- *
-bool UMLData::compareMethods(method_ptr method1, method_ptr method2)
+ * @param className 
+ * @param attributeName 
+ */
+void UMLData::removeClassAttribute(string className, string attributeName)
 {
-
-  if(method1->getType() != method2->getType())
-    return false;
-
-  list paramList1 = method1->getParam();
-  list paramList2 = method2->getParam();
-
-  if(paramList1.size() != paramList2.size())
-    return true;
-
-  auto param2 = paramList2.begin();
-  for(auto param1 = paramList1.begin(); param1 == paramList1.end(); ++param1)
-  {
-    if(param1->getType() != param2->getType())
-      return true;
-
-    ++param2;
+  for (attr_ptr attr : getClass(className).getAttributes()) {
+    if (attr->getAttributeName() == attributeName) {
+      getClass(className).deleteAttribute(attributeName);
+      return;
+    }
   }
-
-  return false; 
+  throw std::runtime_error("Attribute does not exist");
 }
-*/
+
 
 
 /*

--- a/include/UMLData.hpp
+++ b/include/UMLData.hpp
@@ -125,19 +125,13 @@ class UMLData
 
 
     // Takes in class and adds it to vector
-    void addClass(const UMLClass& classIn);
+    void addClassObject(const UMLClass& classIn);
 
     // Takes in string name and creates class and adds to classes vector
     void addClass(string name);
 
-    // Takes in name and vector of attributes and creates class and adds to vector of classes
-    void addClass(string name, vector<UMLAttribute> attributes);
-
     // Takes in src string, dest string, and type int creates relationship and adds to relationships vector
     void addRelationship(string srcName, string destName, int type);
-
-    // Adds class attribute to specified className
-    void addClassAttribute(string className, UMLAttribute attribute);
 
     // Adds class attribute to specified className using a smart pointer
     void addClassAttribute(string className, attr_ptr attribute);
@@ -156,9 +150,6 @@ class UMLData
     // Deletes relationshp based on two strings
     void deleteRelationship(string srcName, string destName);
 
-    // Removes className class attribute by the name
-    void removeClassAttribute(string className, string attributeName);
-
     // Removes className class attribute by smart pointer
     void removeClassAttribute(string className, attr_ptr attr);
 
@@ -173,9 +164,6 @@ class UMLData
     // Changes class name from old name to new name
     void changeClassName(string oldName, string newName);
 
-    // Changes className class attribute by the new attribute name
-    void changeAttributeName(string className, string oldAttributeName, string newAttributeName);
-
     // Overload of changeAttributeName to work with a smart pointer
     void changeAttributeName(string className, attr_ptr attribute, string newAttributeName);
 
@@ -186,7 +174,6 @@ class UMLData
 
     /********************************/
     //Type Changing
-
 
     // Modifies relationship type given a new relationship type 
     void changeRelationshipType(const string& srcName, const string& destName, int newType);
@@ -205,9 +192,6 @@ class UMLData
     // Checks if class exists within classses list (string argument) 
     bool doesClassExist(const string& name);
 
-    // Checks if class exists with classes list (class argument)
-    bool doesClassExist(const UMLClass& uclass);
-
     // Checks to see if relationship exists.
     bool doesRelationshipExist(string source, string destination);
 
@@ -222,6 +206,7 @@ class UMLData
 
     // Gets class reference for the given name
     UMLClass& getClass(string name);
+
     // Checks if identifier name is valid
     bool isValidName(string name);
 
@@ -234,8 +219,8 @@ class UMLData
     //DO NOT USE THIS VERSION!
     void deleteParameter(method_ptr method, string paramName);
 
-    // Checks if overloaded methods have duplicate parameters.
-    //bool compareMethods(method_ptr method1, method_ptr method2);
+    // THIS WILL BE DELETED!!!!!!
+    void removeClassAttribute(string className, string attributeName);
 
 
   private:


### PR DESCRIPTION
In Tests.cpp, I commented out a test that was using an outdated `addClassAttribute()`. I deleted most of the overloads, but UMLServer.cpp is still using some outdated functions. So I can't delete those overloads until UMLServer uses the up-to-date versions. I didn't want to edit UMLServer because other people are working on it, and I don't wanna create a merge conflict.